### PR TITLE
Clean build folder part of compile command

### DIFF
--- a/src/logic/clean-build-folder.ts
+++ b/src/logic/clean-build-folder.ts
@@ -1,0 +1,20 @@
+import rimraf from 'rimraf';
+
+import { LogCallback, PROFILE_BUILD_PATH } from '../common';
+
+export async function cleanBuildFolder(options?: {
+  logCb?: LogCallback;
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    rimraf(PROFILE_BUILD_PATH, error => {
+      if (error) {
+        options?.logCb?.(
+          `Cleaning build folder ./${PROFILE_BUILD_PATH}/ failed with error ${error.message}`
+        );
+        reject(error);
+      }
+      options?.logCb?.(`Cleaning build folder ./${PROFILE_BUILD_PATH}/`);
+      resolve();
+    });
+  });
+}

--- a/src/logic/compile.ts
+++ b/src/logic/compile.ts
@@ -25,6 +25,7 @@ import {
   writeFile,
 } from '../common/io';
 import { exportTypeTemplate } from '../common/templates';
+import { cleanBuildFolder } from './clean-build-folder';
 
 export async function compileProfile(
   path: string
@@ -56,6 +57,9 @@ export async function compile(
     logCb?: LogCallback;
   }
 ): Promise<void> {
+  //Clean build folder (./superface/grid)
+  await cleanBuildFolder(options);
+
   //Get capabilities directories
   const scopes = await getDirectories(`./${CAPABILITIES_DIR}`);
   let profiles: string[];


### PR DESCRIPTION
Cleaning build folder before compiling will help with `check` command errors if in build folder remained capabilities that are not part of current branch.