### PR TITLE
Specify shell for run steps

### DIFF
--- a/.github/workflows/publish_production.yml
+++ b/.github/workflows/publish_production.yml
@@ -22,3 +22,4 @@ jobs:
         uses: ./.github/actions/prepare
       - name: Publish
         run: ./bin/station publish --all --force
+        shell: bash

--- a/.github/workflows/publish_staging.yml
+++ b/.github/workflows/publish_staging.yml
@@ -26,3 +26,4 @@ jobs:
         uses: ./.github/actions/prepare
       - name: Publish
         run: ./bin/station publish --all
+        shell: bash


### PR DESCRIPTION
Missing `shell: bash` is only difference I see compare to `prepare` and `check` actions.