### PR TITLE
Use correct field in response to map templates

### DIFF
--- a/capabilities/communication/email-templates/maps/sendgrid.suma
+++ b/capabilities/communication/email-templates/maps/sendgrid.suma
@@ -16,7 +16,7 @@ map ListTemplates {
     }
 
     response 200 "application/json" {
-      map result body.templates.map((template) => ({
+      map result body.result.map((template) => ({
         id: template.id,
         name: template.name,
       }))


### PR DESCRIPTION
Not sure what I did since I ran tests, but not after latests changes, so I guess thats the reason.

Now passing:

<img width="938" alt="image" src="https://user-images.githubusercontent.com/959390/122902490-c6bb3700-d34e-11eb-905b-05b748834484.png">
