### PR TITLE
Base url must not contain api version

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -38,7 +38,7 @@ We want first gather more content to understand how Comlink maps are written to 
 - Provider name MUST use `-` (dash) as delimiter.
 - Provider Id SHOULD be short and descriptive.
 - Provider Id MUST NOT be misleading.
-- Default service Id for versioned APIs SHOULD match the version.
+- Service base URL MUST NOT contain API version.
 - Security Scheme Id MUST use `-` (dash) as delimiter.
 - Security Scheme Id SHOULD be named same as in provider documentation.
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

Convention not to include API version in baseUrl

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We need to be able to use same provider if api version is changed. So map should be where is specified the API version needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
