### PR TITLE
Align delivery-tracking/shipment-info with conventions

### DIFF
--- a/capabilities/delivery-tracking/shipment-info/maps/__snapshots__/dhl.test.ts.snap
+++ b/capabilities/delivery-tracking/shipment-info/maps/__snapshots__/dhl.test.ts.snap
@@ -10,7 +10,7 @@ Object {
           "countryCode": "DE",
         },
       },
-      "estimatedDeliveryDate": undefined,
+      "estimatedDeliveryDate": null,
       "events": Array [
         Object {
           "location": undefined,
@@ -33,14 +33,6 @@ Object {
       "trackingNumber": "00340434292135100148",
     },
   ],
-}
-`;
-
-exports[`delivery-tracking/shipment-info/dhl ShipmentInfo when inputs are invalid should throw an exception 1`] = `
-Object {
-  "error": "HTTPError: Expected HTTP error
-AST Path: definitions[0].statements[1]
-Original Map Location: Line 11, column 3",
 }
 `;
 

--- a/capabilities/delivery-tracking/shipment-info/maps/__snapshots__/dhl.test.ts.snap
+++ b/capabilities/delivery-tracking/shipment-info/maps/__snapshots__/dhl.test.ts.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`delivery-tracking/shipment-info/dhl ShipmentInfo when all inputs are correct should return shipment info as result 1`] = `
+Object {
+  "value": Array [
+    Object {
+      "carrier": "parcel-de",
+      "destination": Object {
+        "address": Object {
+          "countryCode": "DE",
+        },
+      },
+      "estimatedDeliveryDate": undefined,
+      "events": Array [
+        Object {
+          "location": undefined,
+          "statusCode": "pre_transit",
+          "statusText": "The instruction data for this shipment have been provided by the sender to DHL electronically",
+          "timestamp": "2021-07-06T19:35:00",
+        },
+      ],
+      "origin": Object {
+        "address": Object {
+          "countryCode": "DE",
+        },
+      },
+      "status": Object {
+        "location": undefined,
+        "statusCode": "pre_transit",
+        "statusText": "The instruction data for this shipment have been provided by the sender to DHL electronically",
+        "timestamp": "2021-07-06T19:35:00",
+      },
+      "trackingNumber": "00340434292135100148",
+    },
+  ],
+}
+`;
+
+exports[`delivery-tracking/shipment-info/dhl ShipmentInfo when inputs are invalid should throw an exception 1`] = `
+Object {
+  "error": "HTTPError: Expected HTTP error
+AST Path: definitions[0].statements[1]
+Original Map Location: Line 11, column 3",
+}
+`;
+
+exports[`delivery-tracking/shipment-info/dhl ShipmentInfo when inputs are invalid should throw exception 1`] = `
+Object {
+  "error": "HTTPError: Expected HTTP error
+AST Path: definitions[0].statements[1]
+Original Map Location: Line 11, column 3",
+}
+`;

--- a/capabilities/delivery-tracking/shipment-info/maps/__snapshots__/shippo.test.ts.snap
+++ b/capabilities/delivery-tracking/shipment-info/maps/__snapshots__/shippo.test.ts.snap
@@ -1,0 +1,315 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`delivery-tracking/shipment-info/shippo ShipmentInfo when shipment is delivered should return valid shipment info as result 1`] = `
+Object {
+  "value": Array [
+    Object {
+      "carrier": "shippo",
+      "destination": Object {
+        "address": Object {
+          "addressLocality": "Chicago",
+          "countryCode": "US",
+          "postalCode": "60611",
+        },
+      },
+      "estimatedDeliveryDate": "2021-09-24T16:40:10.049Z",
+      "events": Array [
+        Object {
+          "location": undefined,
+          "statusCode": "unknown",
+          "statusText": "The carrier has received the electronic shipment information.",
+          "timestamp": "2021-09-20T20:18:46.892Z",
+        },
+        Object {
+          "location": Object {
+            "address": Object {
+              "addressLocality": "San Francisco",
+              "countryCode": "US",
+              "postalCode": "94103",
+            },
+          },
+          "statusCode": "transit",
+          "statusText": "Your shipment has departed from the origin.",
+          "timestamp": "2021-09-22T00:18:46.892Z",
+        },
+        Object {
+          "location": Object {
+            "address": Object {
+              "addressLocality": "Memphis",
+              "countryCode": "US",
+              "postalCode": "37501",
+            },
+          },
+          "statusCode": "failure",
+          "statusText": "The Postal Service has identified a problem with the processing of this item and you should contact support to get further information.",
+          "timestamp": "2021-09-23T12:18:46.892Z",
+        },
+        Object {
+          "location": Object {
+            "address": Object {
+              "addressLocality": "Chicago",
+              "countryCode": "US",
+              "postalCode": "60611",
+            },
+          },
+          "statusCode": "delivered",
+          "statusText": "Your shipment has been delivered.",
+          "timestamp": "2021-09-23T00:18:46.892Z",
+        },
+      ],
+      "origin": Object {
+        "address": Object {
+          "addressLocality": "San Francisco",
+          "countryCode": "US",
+          "postalCode": "94103",
+        },
+      },
+      "status": Object {
+        "location": Object {
+          "address": Object {
+            "addressLocality": "Chicago",
+            "countryCode": "US",
+            "postalCode": "60611",
+          },
+        },
+        "statusCode": "delivered",
+        "statusText": "Your shipment has been delivered.",
+        "timestamp": "2021-09-23T00:18:46.892Z",
+      },
+      "trackingNumber": "SHIPPO_DELIVERED",
+    },
+  ],
+}
+`;
+
+exports[`delivery-tracking/shipment-info/shippo ShipmentInfo when shipment is in pre transit should return valid shipment info as result 1`] = `
+Object {
+  "value": Array [
+    Object {
+      "carrier": "shippo",
+      "destination": Object {
+        "address": Object {
+          "addressLocality": "Chicago",
+          "countryCode": "US",
+          "postalCode": "60611",
+        },
+      },
+      "estimatedDeliveryDate": "2021-09-24T16:40:09.232Z",
+      "events": Array [
+        Object {
+          "location": undefined,
+          "statusCode": "pre_transit",
+          "statusText": "The carrier has received the electronic shipment information.",
+          "timestamp": "2021-09-20T20:18:39.827Z",
+        },
+      ],
+      "origin": Object {
+        "address": Object {
+          "addressLocality": "San Francisco",
+          "countryCode": "US",
+          "postalCode": "94103",
+        },
+      },
+      "status": Object {
+        "location": undefined,
+        "statusCode": "pre_transit",
+        "statusText": "The carrier has received the electronic shipment information.",
+        "timestamp": "2021-09-20T20:18:39.827Z",
+      },
+      "trackingNumber": "SHIPPO_PRE_TRANSIT",
+    },
+  ],
+}
+`;
+
+exports[`delivery-tracking/shipment-info/shippo ShipmentInfo when shipment is in transit should return valid shipment info as result 1`] = `
+Object {
+  "value": Array [
+    Object {
+      "carrier": "shippo",
+      "destination": Object {
+        "address": Object {
+          "addressLocality": "Chicago",
+          "countryCode": "US",
+          "postalCode": "60611",
+        },
+      },
+      "estimatedDeliveryDate": "2021-09-24T16:40:09.639Z",
+      "events": Array [
+        Object {
+          "location": undefined,
+          "statusCode": "unknown",
+          "statusText": "The carrier has received the electronic shipment information.",
+          "timestamp": "2021-09-20T20:19:04.084Z",
+        },
+        Object {
+          "location": Object {
+            "address": Object {
+              "addressLocality": "San Francisco",
+              "countryCode": "US",
+              "postalCode": "94103",
+            },
+          },
+          "statusCode": "transit",
+          "statusText": "Your shipment has departed from the origin.",
+          "timestamp": "2021-09-22T00:19:04.084Z",
+        },
+      ],
+      "origin": Object {
+        "address": Object {
+          "addressLocality": "San Francisco",
+          "countryCode": "US",
+          "postalCode": "94103",
+        },
+      },
+      "status": Object {
+        "location": Object {
+          "address": Object {
+            "addressLocality": "San Francisco",
+            "countryCode": "US",
+            "postalCode": "94103",
+          },
+        },
+        "statusCode": "transit",
+        "statusText": "Your shipment has departed from the origin.",
+        "timestamp": "2021-09-22T00:19:04.084Z",
+      },
+      "trackingNumber": "SHIPPO_TRANSIT",
+    },
+  ],
+}
+`;
+
+exports[`delivery-tracking/shipment-info/shippo ShipmentInfo when shipment is returned should return valid shipment info as result 1`] = `
+Object {
+  "value": Array [
+    Object {
+      "carrier": "shippo",
+      "destination": Object {
+        "address": Object {
+          "addressLocality": "Chicago",
+          "countryCode": "US",
+          "postalCode": "60611",
+        },
+      },
+      "estimatedDeliveryDate": "2021-09-24T16:40:10.6Z",
+      "events": Array [
+        Object {
+          "location": undefined,
+          "statusCode": "unknown",
+          "statusText": "The carrier has received the electronic shipment information.",
+          "timestamp": "2021-09-20T20:19:04.084Z",
+        },
+        Object {
+          "location": Object {
+            "address": Object {
+              "addressLocality": "San Francisco",
+              "countryCode": "US",
+              "postalCode": "94103",
+            },
+          },
+          "statusCode": "transit",
+          "statusText": "Your shipment has departed from the origin.",
+          "timestamp": "2021-09-22T00:19:04.084Z",
+        },
+        Object {
+          "location": Object {
+            "address": Object {
+              "addressLocality": "Memphis",
+              "countryCode": "US",
+              "postalCode": "37501",
+            },
+          },
+          "statusCode": "failure",
+          "statusText": "The Postal Service has identified a problem with the processing of this item and you should contact support to get further information.",
+          "timestamp": "2021-09-23T12:19:04.084Z",
+        },
+        Object {
+          "location": Object {
+            "address": Object {
+              "addressLocality": "Chicago",
+              "countryCode": "US",
+              "postalCode": "60611",
+            },
+          },
+          "statusCode": "delivered",
+          "statusText": "Your shipment has been delivered.",
+          "timestamp": "2021-09-23T00:19:04.084Z",
+        },
+        Object {
+          "location": Object {
+            "address": Object {
+              "addressLocality": "San Francisco",
+              "countryCode": "US",
+              "postalCode": "94103",
+            },
+          },
+          "statusCode": "unknown",
+          "statusText": "Your shipment has been returned to the original sender.",
+          "timestamp": "2021-09-23T20:19:04.084Z",
+        },
+      ],
+      "origin": Object {
+        "address": Object {
+          "addressLocality": "San Francisco",
+          "countryCode": "US",
+          "postalCode": "94103",
+        },
+      },
+      "status": Object {
+        "location": Object {
+          "address": Object {
+            "addressLocality": "San Francisco",
+            "countryCode": "US",
+            "postalCode": "94103",
+          },
+        },
+        "statusCode": "unknown",
+        "statusText": "Your shipment has been returned to the original sender.",
+        "timestamp": "2021-09-23T20:19:04.084Z",
+      },
+      "trackingNumber": "SHIPPO_RETURNED",
+    },
+  ],
+}
+`;
+
+exports[`delivery-tracking/shipment-info/shippo ShipmentInfo when shipment status is unknown should return valid shipment info as result 1`] = `
+Object {
+  "value": Array [
+    Object {
+      "carrier": "shippo",
+      "destination": Object {
+        "address": Object {
+          "addressLocality": "Chicago",
+          "countryCode": "US",
+          "postalCode": "60611",
+        },
+      },
+      "estimatedDeliveryDate": "2021-09-24T16:40:11.038Z",
+      "events": Array [
+        Object {
+          "location": undefined,
+          "statusCode": "unknown",
+          "statusText": "The carrier has received the electronic shipment information.",
+          "timestamp": "2021-09-20T20:19:08.242Z",
+        },
+      ],
+      "origin": Object {
+        "address": Object {
+          "addressLocality": "San Francisco",
+          "countryCode": "US",
+          "postalCode": "94103",
+        },
+      },
+      "status": Object {
+        "location": undefined,
+        "statusCode": "unknown",
+        "statusText": "The carrier has received the electronic shipment information.",
+        "timestamp": "2021-09-20T20:19:08.242Z",
+      },
+      "trackingNumber": "SHIPPO_UNKNOWN",
+    },
+  ],
+}
+`;

--- a/capabilities/delivery-tracking/shipment-info/maps/dhl.suma
+++ b/capabilities/delivery-tracking/shipment-info/maps/dhl.suma
@@ -1,6 +1,6 @@
 //DHL API reference: https://developer.dhl.com/api-reference/shipment-tracking
 
-profile = "delivery-tracking/shipment-info@1.0"
+profile = "delivery-tracking/shipment-info@1.1"
 provider = "dhl"
 
 map ShipmentInfo {

--- a/capabilities/delivery-tracking/shipment-info/maps/dhl.suma
+++ b/capabilities/delivery-tracking/shipment-info/maps/dhl.suma
@@ -1,9 +1,8 @@
+//DHL API reference: https://developer.dhl.com/api-reference/shipment-tracking
+
 profile = "delivery-tracking/shipment-info@1.0"
 provider = "dhl"
 
-"""
-ShipmentInfo map
-"""
 map ShipmentInfo {
   fetchShipmentOutcome = call FetchShipment(
     trackingNumber = input.trackingNumber,
@@ -76,6 +75,7 @@ operation MapShipment {
     status = status
     events = events
     estimatedDeliveryDate = estimatedDeliveryDate
+    carrier = shipment.service
   }
 }
 

--- a/capabilities/delivery-tracking/shipment-info/maps/dhl.suma
+++ b/capabilities/delivery-tracking/shipment-info/maps/dhl.suma
@@ -51,7 +51,7 @@ operation FetchShipment {
 }
 
 operation MapShipment {
-  estimatedDeliveryDate = undefined
+  estimatedDeliveryDate = null
   shipment = args.shipment
 
   set if (shipment.estimatedDeliveryDate) {

--- a/capabilities/delivery-tracking/shipment-info/maps/dhl.test.ts
+++ b/capabilities/delivery-tracking/shipment-info/maps/dhl.test.ts
@@ -1,67 +1,18 @@
-import { SuperfaceClient } from '../../../../superface/sdk';
+import { shipmentInfoTest } from './shipment-info';
 
-describe('delivery-tracking/shipment-info/dhl', () => {
-  it('should define use-case and provider', async () => {
-    const client = new SuperfaceClient();
-    const profile = await client.getProfile('delivery-tracking/shipment-info');
-    const useCase = profile.getUseCase('ShipmentInfo');
-    const provider = await client.getProvider('dhl');
-
-    expect(useCase).not.toBeUndefined();
-    expect(provider).not.toBeUndefined();
-  });
-
-  describe('valid tracking number', () => {
-    let shipment: any;
-    beforeAll(async () => {
-      const client = new SuperfaceClient();
-      const profile = await client.getProfile(
-        'delivery-tracking/shipment-info'
-      );
-      const dhl = await client.getProvider('dhl');
-      const result = await profile.useCases.ShipmentInfo.perform(
-        { trackingNumber: '00340434292135100131' },
-        { provider: dhl }
-      );
-      shipment = result.unwrap()[0];
-    });
-    it('should return valid tracking number', () => {
-      expect(shipment.trackingNumber).toBe('00340434292135100131');
-    });
-    it('should return valid origin location', () => {
-      expect(shipment.origin).toEqual({
-        address: {
-          countryCode: 'DE',
-        },
-      });
-    });
-    it('should return valid destination location', () => {
-      expect(shipment.destination).toEqual({
-        address: {
-          countryCode: 'DE',
-        },
-      });
-    });
-    it('should return valid status', () => {
-      expect(shipment.status.statusCode).toEqual('pre_transit');
-      expect(shipment.status.statusText).toEqual(
-        'The instruction data for this shipment have been provided by the sender to DHL electronically'
-      );
-      expect(shipment.status.timestamp).toBeDefined();
-    });
-    it('should return events', () => {
-      expect(shipment.events.length).toBe(1);
-    });
-  });
-
-  it('should return error for not existing tracking number', async () => {
-    const client = new SuperfaceClient();
-    const profile = await client.getProfile('delivery-tracking/shipment-info');
-    const dhl = await client.getProvider('dhl');
-    const result = await profile.useCases.ShipmentInfo.perform(
-      { trackingNumber: 'NOT_EXISTING_TRACKING_NUMBER' },
-      { provider: dhl }
-    );
-    expect(result.isErr()).toBeTruthy();
-  });
-});
+shipmentInfoTest('dhl', [
+  {
+    input: {
+      trackingNumber: '00340434292135100148',
+    },
+    describe: 'when all inputs are correct',
+    expectedResult: 'should return shipment info as result',
+  },
+  {
+    input: {
+      trackingNumber: 'NOT_EXISTING_TRACKING_NUMBER',
+    },
+    describe: 'when inputs are invalid',
+    expectedResult: 'should throw exception',
+  },
+]);

--- a/capabilities/delivery-tracking/shipment-info/maps/mock.suma
+++ b/capabilities/delivery-tracking/shipment-info/maps/mock.suma
@@ -1,4 +1,4 @@
-profile = "delivery-tracking/shipment-info@1.0"
+profile = "delivery-tracking/shipment-info@1.1"
 provider = "mock"
 
 map ShipmentInfo {

--- a/capabilities/delivery-tracking/shipment-info/maps/shipment-info.ts
+++ b/capabilities/delivery-tracking/shipment-info/maps/shipment-info.ts
@@ -1,0 +1,37 @@
+/* eslint-disable jest/no-export */
+
+import { SuperfaceTest } from '@superfaceai/testing-lib';
+
+export const shipmentInfoTest = (
+  provider: string,
+  testVectors: {
+    input: { trackingNumber: string; carrier?: string };
+    describe: string;
+    expectedResult: string;
+  }[]
+): void => {
+  describe(`delivery-tracking/shipment-info/${provider}`, () => {
+    let superface: SuperfaceTest;
+
+    beforeEach(() => {
+      superface = new SuperfaceTest();
+    });
+
+    describe('ShipmentInfo', () => {
+      testVectors.forEach(testVector => {
+        describe(testVector.describe, () => {
+          it(testVector.expectedResult, async () => {
+            await expect(
+              superface.run({
+                profile: 'delivery-tracking/shipment-info',
+                provider,
+                useCase: 'ShipmentInfo',
+                input: testVector.input,
+              })
+            ).resolves.toMatchSnapshot();
+          });
+        });
+      });
+    });
+  });
+};

--- a/capabilities/delivery-tracking/shipment-info/maps/shippo.suma
+++ b/capabilities/delivery-tracking/shipment-info/maps/shippo.suma
@@ -42,7 +42,7 @@ operation FetchShipment {
 }
 
 operation MapShipment {
-  estimatedDeliveryDate = undefined
+  estimatedDeliveryDate = null
   shipment = args.shipment
 
   set if (shipment.eta) {

--- a/capabilities/delivery-tracking/shipment-info/maps/shippo.suma
+++ b/capabilities/delivery-tracking/shipment-info/maps/shippo.suma
@@ -1,9 +1,8 @@
+//Shippo API reference: https://goshippo.com/docs/reference#tracks-retrieve
+
 profile = "delivery-tracking/shipment-info@1.0"
   provider = "shippo"
   
-"""
-ShipmentInfo map
-"""
 map ShipmentInfo {
   fetchShipmentOutcome = call FetchShipment(
     carrier = input.carrier,
@@ -65,6 +64,7 @@ operation MapShipment {
     status = status
     events = events
     estimatedDeliveryDate = estimatedDeliveryDate
+    carrier = shipment.carrier
   }
 }
 

--- a/capabilities/delivery-tracking/shipment-info/maps/shippo.suma
+++ b/capabilities/delivery-tracking/shipment-info/maps/shippo.suma
@@ -1,6 +1,6 @@
 //Shippo API reference: https://goshippo.com/docs/reference#tracks-retrieve
 
-profile = "delivery-tracking/shipment-info@1.0"
+profile = "delivery-tracking/shipment-info@1.1"
   provider = "shippo"
   
 map ShipmentInfo {

--- a/capabilities/delivery-tracking/shipment-info/maps/shippo.test.ts
+++ b/capabilities/delivery-tracking/shipment-info/maps/shippo.test.ts
@@ -1,91 +1,44 @@
-import { SuperfaceClient } from '../../../../superface/sdk';
+import { shipmentInfoTest } from './shipment-info';
 
-describe('delivery-tracking/shipment-info/shippo', () => {
-  it('should define use-case and provider', async () => {
-    const client = new SuperfaceClient();
-    const profile = await client.getProfile('delivery-tracking/shipment-info');
-    const useCase = profile.getUseCase('ShipmentInfo');
-    const provider = await client.getProvider('shippo');
-
-    expect(useCase).not.toBeUndefined();
-    expect(provider).not.toBeUndefined();
-  });
-
-  describe('for tracking number in pre-transit', () => {
-    let shipment: any;
-    beforeAll(async () => {
-      const client = new SuperfaceClient();
-      const profile = await client.getProfile(
-        'delivery-tracking/shipment-info'
-      );
-      const shippo = await client.getProvider('shippo');
-      const result = await profile.useCases.ShipmentInfo.perform(
-        { carrier: 'shippo', trackingNumber: 'SHIPPO_PRE_TRANSIT' },
-        { provider: shippo }
-      );
-      shipment = result.unwrap()[0];
-    });
-
-    it('should return valid origin location', () => {
-      expect(shipment.origin).toEqual({
-        address: {
-          addressLocality: 'San Francisco',
-          countryCode: 'US',
-          postalCode: '94103',
-        },
-      });
-    });
-
-    it('should return valid destination location', () => {
-      expect(shipment.destination).toEqual({
-        address: {
-          addressLocality: 'Chicago',
-          countryCode: 'US',
-          postalCode: '60611',
-        },
-      });
-    });
-
-    it('should return valid status', () => {
-      expect(shipment.status.statusCode).toBe('pre_transit');
-      expect(shipment.status.statusText).toBe(
-        'The carrier has received the electronic shipment information.'
-      );
-    });
-
-    it('should return events', () => {
-      expect(shipment.events.length).toBe(1);
-    });
-  });
-
-  describe('for tracking number in transit', () => {
-    let shipment: any;
-    beforeAll(async () => {
-      const client = new SuperfaceClient();
-      const profile = await client.getProfile(
-        'delivery-tracking/shipment-info'
-      );
-      const shippo = await client.getProvider('shippo');
-      const result = await profile.useCases.ShipmentInfo.perform(
-        { carrier: 'shippo', trackingNumber: 'SHIPPO_TRANSIT' },
-        { provider: shippo }
-      );
-      shipment = result.unwrap()[0];
-    });
-
-    it('should return valid status', () => {
-      expect(shipment.status.statusCode).toBe('transit');
-      expect(shipment.status.statusText).toBe(
-        'Your shipment has departed from the origin.'
-      );
-    });
-
-    it('should return events', () => {
-      expect(shipment.events.length).toBe(2);
-    });
-
-    it('should return estimated delivery date', () => {
-      expect(shipment.estimatedDeliveryDate).toBeDefined();
-    });
-  });
-});
+shipmentInfoTest('shippo', [
+  {
+    input: {
+      trackingNumber: 'SHIPPO_PRE_TRANSIT',
+      carrier: 'shippo',
+    },
+    describe: 'when shipment is in pre transit',
+    expectedResult: 'should return valid shipment info as result',
+  },
+  {
+    input: {
+      trackingNumber: 'SHIPPO_TRANSIT',
+      carrier: 'shippo',
+    },
+    describe: 'when shipment is in transit',
+    expectedResult: 'should return valid shipment info as result',
+  },
+  {
+    input: {
+      trackingNumber: 'SHIPPO_DELIVERED',
+      carrier: 'shippo',
+    },
+    describe: 'when shipment is delivered',
+    expectedResult: 'should return valid shipment info as result',
+  },
+  {
+    input: {
+      trackingNumber: 'SHIPPO_RETURNED',
+      carrier: 'shippo',
+    },
+    describe: 'when shipment is returned',
+    expectedResult: 'should return valid shipment info as result',
+  },
+  {
+    input: {
+      trackingNumber: 'SHIPPO_UNKNOWN',
+      carrier: 'shippo',
+    },
+    describe: 'when shipment status is unknown',
+    expectedResult: 'should return valid shipment info as result',
+  },
+]);

--- a/capabilities/delivery-tracking/shipment-info/profile.supr
+++ b/capabilities/delivery-tracking/shipment-info/profile.supr
@@ -16,13 +16,13 @@ usecase ShipmentInfo safe {
     Shipment tracking number
     The identifier of shipment.
     """
-    trackingNumber! string
+    trackingNumber! string!
 
     """
     Carrier
     The shipment carrier identification to narrow down the results.
     """
-    carrier string
+    carrier string!
   }
 
   result [{

--- a/capabilities/delivery-tracking/shipment-info/profile.supr
+++ b/capabilities/delivery-tracking/shipment-info/profile.supr
@@ -77,6 +77,7 @@ usecase ShipmentInfo safe {
     title!
 
     """
+    Detail
     A human-readable explanation specific to this occurrence of the problem.
     """
     detail
@@ -153,7 +154,7 @@ model Location {
   address! {
   """
   Country code
-   A short text string code (ISO 3166-1 alpha-2 country code) specifying the country.
+A short text string code (ISO 3166-1 alpha-2 country code) specifying the country.
   """
   countryCode string
 

--- a/capabilities/delivery-tracking/shipment-info/profile.supr
+++ b/capabilities/delivery-tracking/shipment-info/profile.supr
@@ -1,90 +1,178 @@
 """
 Shipment information
-
 Track your shipment. Get the latest information on your shipment status. 
 """
 
 name = "delivery-tracking/shipment-info"
-version = "1.0.1"
+version = "1.0.2"
 
 """
 Retrieve Shipment Status
-
-Get the actual shipment status.
+Get the current shipment status.
 """
 usecase ShipmentInfo safe {
   input {
-    "Shipment tracking number
-    Identifier of shipment"
+    """
+    Shipment tracking number
+    The identifier of shipment.
+    """
     trackingNumber! string
 
-    "Carrier
-    Shipment carrier identification"
+    """
+    Carrier
+    The shipment carrier identification to narrow down the results.
+    """
     carrier string
   }
 
   result [{
-    "Carrier
-    Shipment carrier identification"
+    """
+    Carrier
+    The name of the carrier responsible for delivery.
+    """
     carrier! string
 
-    "Shipment tracking number
-    Identifier of shipment"
-    trackingNumber! string
-
-    origin! Location
-    destination! Location
+    """
+    Status
+    The latest shipment event.
+    """
     status ShipmentEvent
+
+    """
+    Origin
+    A postal address with the origin of the shipment.
+    """
+    origin! Location
+
+    """
+    Shipment tracking number
+    The identifier of shipment.
+    """
+    trackingNumber! string
+    
+    """
+    Destination
+    A postal shipping address.
+    """
+    destination! Location
+
+    """
+    Events
+    A list of delivery tracking events.
+    """
     events! [ShipmentEvent]
 
-    "Estimated date and time of delivery"
+    """
+    Estimated delivery date
+    Estimated date and time of delivery.
+    """
     estimatedDeliveryDate string
   }]
 
   error {
-    title! string
+    """
+    Title
+    A short, human-readable summary of the problem type.
+    """
+    title!
+
+    """
+    A human-readable explanation specific to this occurrence of the problem.
+    """
+    detail
   }
 }
 
-"
+"""
 Shipment status
-Status of a shipment. Harmonized across different carriers.
-"
+The status of the shipment. Harmonized across different carriers.
+"""
 model ShipmentStatus enum {
+  """
+  Pre-Transit
+  Carrier has received information about the package but it has not yet been scanned and picked up.
+  """
   pre_transit
+  """
+  Transit
+  A package is traveling to its destination.
+  """
   transit
+  """
+  Delivered
+  The package has been delivered.
+  """
   delivered
+  """
+  Failure
+  The package encountered an error during transit.
+  """
   failure
+  """
+  Unknown
+  The shipment status is unknown.
+  """
   unknown
 }
 
+"""
+Shipment event
+The shipment event information.
+"""
 model ShipmentEvent {
+  """
+  Timestamp
+  The date and time in ISO 8601 format of the event.
+  """
   timestamp! string
+
+  """
+  Shipment status
+  The shipment status of the event.
+  """
   statusCode! ShipmentStatus
+
+  """
+  Status
+  A description of the current shipment status.
+  """
   statusText! string
+
+  """
+  Location
+  The location of the shipment.
+  """
   location Location
 }
 
+"""
+Location
+A shipment location.
+"""
 model Location {
-  address! Address
-}
-
-model Address {
-
-  "Country code
-   A short text string code (ISO 3166-1 alpha-2 country code) specifying the country."
+  address! {
+  """
+  Country code
+   A short text string code (ISO 3166-1 alpha-2 country code) specifying the country.
+  """
   countryCode string
 
-  "Postal code
-   Text specifying the postal code for an address."
+  """
+  Postal code
+  Text specifying the postal code for an address.
+  """
   postalCode string
 
-  "Address locality
-   Text specifying the name of the locality, for example a city."
+  """
+  Address locality
+  Text specifying the name of the locality, for example a city.
+  """
   addressLocality string
 
-  "Street address
-   The street address expressed as free form text. The street address is printed on paper as the first lines below the name."
+  """
+  Street address
+  The street address expressed as free form text. The street address is printed on paper as the first lines below the name.
+  """
   streetAddress string
-
+  }
 }

--- a/capabilities/delivery-tracking/shipment-info/profile.supr
+++ b/capabilities/delivery-tracking/shipment-info/profile.supr
@@ -156,28 +156,28 @@ A shipment location.
 """
 model Location {
   address! {
-  """
-  Country code
-A short text string code (ISO 3166-1 alpha-2 country code) specifying the country.
-  """
-  countryCode string
+    """
+    Country code
+    A short text string code (ISO 3166-1 alpha-2 country code) specifying the country.
+    """
+    countryCode string
 
-  """
-  Postal code
-  Text specifying the postal code for an address.
-  """
-  postalCode string
+    """
+    Postal code
+    Text specifying the postal code for an address.
+    """
+    postalCode string
 
-  """
-  Address locality
-  Text specifying the name of the locality, for example a city.
-  """
-  addressLocality string
+    """
+    Address locality
+    Text specifying the name of the locality, for example a city.
+    """
+    addressLocality string
 
-  """
-  Street address
-  The street address expressed as free form text. The street address is printed on paper as the first lines below the name.
-  """
-  streetAddress string
+    """
+    Street address
+    The street address expressed as free form text. The street address is printed on paper as the first lines below the name.
+    """
+    streetAddress string
   }
 }

--- a/capabilities/delivery-tracking/shipment-info/profile.supr
+++ b/capabilities/delivery-tracking/shipment-info/profile.supr
@@ -36,7 +36,7 @@ usecase ShipmentInfo safe {
     Status
     The latest shipment event.
     """
-    status ShipmentEvent
+    status! ShipmentEvent
 
     """
     Origin
@@ -60,13 +60,13 @@ usecase ShipmentInfo safe {
     Events
     A list of delivery tracking events.
     """
-    events! [ShipmentEvent]
+    events! [ShipmentEvent!]!
 
     """
     Estimated delivery date
     Estimated date and time of delivery.
     """
-    estimatedDeliveryDate string
+    estimatedDeliveryDate! string
   }]
 
   error {

--- a/capabilities/delivery-tracking/shipment-info/profile.supr
+++ b/capabilities/delivery-tracking/shipment-info/profile.supr
@@ -4,7 +4,7 @@ Track your shipment. Get the latest information on your shipment status.
 """
 
 name = "delivery-tracking/shipment-info"
-version = "1.0.2"
+version = "1.1.0"
 
 """
 Retrieve Shipment Status

--- a/capabilities/delivery-tracking/shipment-info/profile.supr
+++ b/capabilities/delivery-tracking/shipment-info/profile.supr
@@ -94,21 +94,25 @@ model ShipmentStatus enum {
   Carrier has received information about the package but it has not yet been scanned and picked up.
   """
   pre_transit
+
   """
   Transit
   A package is traveling to its destination.
   """
   transit
+
   """
   Delivered
   The package has been delivered.
   """
   delivered
+
   """
   Failure
   The package encountered an error during transit.
   """
   failure
+
   """
   Unknown
   The shipment status is unknown.

--- a/nock/delivery-tracking/shipment-info/dhl/ShipmentInfo/recording.json
+++ b/nock/delivery-tracking/shipment-info/dhl/ShipmentInfo/recording.json
@@ -1,0 +1,168 @@
+[
+  {
+    "scope": "https://api-eu.dhl.com:443",
+    "method": "GET",
+    "path": "/track/shipments?trackingNumber=00340434292135100148",
+    "body": "",
+    "status": 200,
+    "response": {
+      "shipments": [
+        {
+          "serviceUrl": "https://www.dhl.de/de/privatkunden.html?piececode=00340434292135100148&cid=c_dhl_de_352_20205002_151_M040",
+          "rerouteUrl": "https://www.dhl.de/de/privatkunden.html?piececode=00340434292135100148&verfuegen_selected_tab=FIRST&cid=c_dhl_de_352_20205001_150_M040",
+          "id": "00340434292135100148",
+          "service": "parcel-de",
+          "origin": {
+            "address": {
+              "countryCode": "DE"
+            }
+          },
+          "destination": {
+            "address": {
+              "countryCode": "DE"
+            }
+          },
+          "status": {
+            "timestamp": "2021-07-06T19:35:00",
+            "statusCode": "pre-transit",
+            "status": "The instruction data for this shipment have been provided by the sender to DHL electronically",
+            "description": "The instruction data for this shipment have been provided by the sender to DHL electronically"
+          },
+          "details": {
+            "product": {
+              "productName": "DHL PAKET (parcel)"
+            },
+            "totalNumberOfPieces": 1,
+            "pieceIds": [
+              "340434292135100148"
+            ],
+            "weight": {
+              "value": 2,
+              "unitText": "kg"
+            },
+            "dimensions": {
+              "width": {
+                "value": 0.3,
+                "unitText": "m"
+              },
+              "height": {
+                "value": 0.14,
+                "unitText": "m"
+              },
+              "length": {
+                "value": 0.38,
+                "unitText": "m"
+              }
+            }
+          },
+          "events": [
+            {
+              "timestamp": "2021-07-06T19:35:00",
+              "statusCode": "pre-transit",
+              "status": "The instruction data for this shipment have been provided by the sender to DHL electronically",
+              "description": "The instruction data for this shipment have been provided by the sender to DHL electronically"
+            }
+          ]
+        }
+      ],
+      "possibleAdditionalShipmentsUrl": [
+        "/track/shipments?trackingNumber=00340434292135100148&service=freight",
+        "/track/shipments?trackingNumber=00340434292135100148&service=dgf",
+        "/track/shipments?trackingNumber=00340434292135100148&service=ecommerce",
+        "/track/shipments?trackingNumber=00340434292135100148&service=parcel-nl",
+        "/track/shipments?trackingNumber=00340434292135100148&service=parcel-pl",
+        "/track/shipments?trackingNumber=00340434292135100148&service=post-de",
+        "/track/shipments?trackingNumber=00340434292135100148&service=sameday",
+        "/track/shipments?trackingNumber=00340434292135100148&service=parcel-uk"
+      ]
+    },
+    "rawHeaders": [
+      "Date",
+      "Fri, 24 Sep 2021 16:08:12 GMT",
+      "Content-Type",
+      "application/json",
+      "Content-Length",
+      "1894",
+      "Connection",
+      "close",
+      "Content-Language",
+      "en",
+      "Correlation-Id",
+      "9a50dd80-f977-4d55-af1f-efe34ecd057d",
+      "access-control-allow-origin",
+      "*",
+      "access-control-allow-headers",
+      "origin,x-requested-with,accept,content-type,dhl-api-key",
+      "access-control-max-age",
+      "3628800",
+      "access-control-allow-methods",
+      "GET,OPTIONS"
+    ],
+    "reqheaders": {
+      "accept": [
+        "*/*"
+      ],
+      "dhl-api-key": [
+        "demo-key"
+      ],
+      "accept-encoding": [
+        "gzip,deflate"
+      ],
+      "connection": [
+        "close"
+      ],
+      "host": "api-eu.dhl.com"
+    },
+    "responseIsBinary": false
+  },
+  {
+    "scope": "https://api-eu.dhl.com:443",
+    "method": "GET",
+    "path": "/track/shipments?trackingNumber=NOT_EXISTING_TRACKING_NUMBER",
+    "body": "",
+    "status": 404,
+    "response": {
+      "title": "No result found",
+      "status": 404,
+      "detail": "No shipment with given tracking number found."
+    },
+    "rawHeaders": [
+      "Date",
+      "Fri, 24 Sep 2021 16:08:13 GMT",
+      "Content-Type",
+      "application/problem+json",
+      "Content-Length",
+      "97",
+      "Connection",
+      "close",
+      "Correlation-Id",
+      "d7928b91-eb08-4237-8085-7a943e0b424f",
+      "Content-Language",
+      "en",
+      "access-control-allow-origin",
+      "*",
+      "access-control-allow-headers",
+      "origin,x-requested-with,accept,content-type,dhl-api-key",
+      "access-control-max-age",
+      "3628800",
+      "access-control-allow-methods",
+      "GET,OPTIONS"
+    ],
+    "reqheaders": {
+      "accept": [
+        "*/*"
+      ],
+      "dhl-api-key": [
+        "demo-key"
+      ],
+      "accept-encoding": [
+        "gzip,deflate"
+      ],
+      "connection": [
+        "close"
+      ],
+      "host": "api-eu.dhl.com"
+    },
+    "responseIsBinary": false
+  }
+]

--- a/nock/delivery-tracking/shipment-info/shippo/ShipmentInfo/recording.json
+++ b/nock/delivery-tracking/shipment-info/shippo/ShipmentInfo/recording.json
@@ -1,0 +1,222 @@
+[
+  {
+    "scope": "https://api.goshippo.com:443",
+    "method": "GET",
+    "path": "/tracks/shippo/SHIPPO_PRE_TRANSIT",
+    "body": "",
+    "status": 200,
+    "response": [
+      "1f8b0800000000000003ec524d6fdb300cfd2b82ce6920399a6bfb56141b16601f41e35d5a14062329b1565b322439c056e4bf8fcad77c18b661e7dd28f1f1f1918faf347a902fc6ee1a3bf61bed6945d7ef97abd5e766f5f0b6a91fee3ead97359d5109de9b633ab466181c7e05edf746ea4eef7547ab576aa1d7985f79e3bc89dfc847301dc2a27bd1f65ad70ce7343dcc526f1b4046e31060c7ae9b5150caeb109aad777d2295098a9ac09277889626c863ef083135bbbfc3c7773360580ace1649a91b6df4a9e8cb3a35b9304637e1bb6f8d84dd9469f9e1ca94b39cf35f30e90818672ce337acbcc944cdf34ab08a95f36c913d62010eb63316bae68fc81e110a8ea8f5712f24ea10c9c58cb4367cd32afa51cf7e7a94c48e21cd718a1a75127fedc4ea8c55bca816e5bcc86e1fcff3252036341d96d2bad5e4ec26692110afa5367bad48c404ba29a377d64892fceab58dc4d8adf33d2497e648d8390953c7c2b8b9c83a7db8cd572469a4d7284efd5edd193b0eeaafb126c18aa2001039144229b1d8e62085c8d8f696bfe1a2e422bf0e9e0e7272c887c9325b13a24bf63efd5fe7bfaef3399d7208b0d3987a7a3efc000000ffff030028c343c750040000"
+    ],
+    "rawHeaders": [
+      "Date",
+      "Fri, 24 Sep 2021 16:40:09 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "x-envoy-upstream-service-time",
+      "15",
+      "server",
+      "istio-envoy",
+      "content-encoding",
+      "gzip",
+      "vary",
+      "Accept-Encoding"
+    ],
+    "reqheaders": {
+      "accept": [
+        "*/*"
+      ],
+      "authorization": [
+        "ShippoToken shippo_test_26299434b7073941a967ae47719e0dca56927590"
+      ],
+      "accept-encoding": [
+        "gzip,deflate"
+      ],
+      "connection": [
+        "close"
+      ],
+      "host": "api.goshippo.com"
+    },
+    "responseIsBinary": false
+  },
+  {
+    "scope": "https://api.goshippo.com:443",
+    "method": "GET",
+    "path": "/tracks/shippo/SHIPPO_TRANSIT",
+    "body": "",
+    "status": 200,
+    "response": [
+      "1f8b0800000000000003ec945d6bdb301486ff8ad1751ae48f38b1ef4a612c6c4bc3e252d6528c2c9d245a6dc94872602bfdef3bb2933463cbbac176b73bc97acfd7f34a7e22ce30fe28d5a6545d5381213959bd9d2f97d765f1f172b19a176444383346f647762bdb56e3270b662739d4b0839ae44f44b106f07c69a436d27d093e3059a3cce94750c7b8b2dd1f93e791afab2ce34e6a14a8aeae47840961c0da726d74e393722fc57e980adea09a4bcbfbda8e395fecea12375f658bcb2c0969ec3bd59d72c607ddac7c914346a74ff25d6d25679bd34cf3f7c74c294dc3f02799c0315c47340a2f687611254598e609cd69364ee3ec0e0370b08d54ac2e5f5536a810ac57ad7a2e8103eb8283111e1bee49ee4c07a3177f7cb39df5730cab520ccd1f2b4505a57998e53419d35972b79fcf0bb1a0ac31947cd29d09bc190d28176c990d04b4cc381081871eb82d04c320630caf3567833f7fc30bdb55871106bb75f519b82bb901cc217e3dc95edbb5e2b7b5b297a5d124e6b198c0344d78023360229b846296409c4d393b4242ede1c23f9f40df4aebb41fe2fe2c765a44af612f10ebfe11f5d00d70903b84ee79e323e2ce6825f98b3352adb5697af8df1b3190fb03943f76771ee5596d8f924f290da3585440a7492878b64e926c364d6346a38a56eb5394378b778bebdb05a2fc7f5bfff56d7df07f146bd906f0f3fdc3f337000000ffff0300a7541be4d3050000"
+    ],
+    "rawHeaders": [
+      "Date",
+      "Fri, 24 Sep 2021 16:40:09 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "x-envoy-upstream-service-time",
+      "17",
+      "server",
+      "istio-envoy",
+      "content-encoding",
+      "gzip",
+      "vary",
+      "Accept-Encoding"
+    ],
+    "reqheaders": {
+      "accept": [
+        "*/*"
+      ],
+      "authorization": [
+        "ShippoToken shippo_test_26299434b7073941a967ae47719e0dca56927590"
+      ],
+      "accept-encoding": [
+        "gzip,deflate"
+      ],
+      "connection": [
+        "close"
+      ],
+      "host": "api.goshippo.com"
+    },
+    "responseIsBinary": false
+  },
+  {
+    "scope": "https://api.goshippo.com:443",
+    "method": "GET",
+    "path": "/tracks/shippo/SHIPPO_DELIVERED",
+    "body": "",
+    "status": 200,
+    "response": [
+      "1f8b0800000000000003ec955d4fdb301486ff8a956b40ce0749d33b0445ab06a5a261d340a872ec93d6238923c7616288ffbee3a4943296f275bbbbd87e7dcef1f3da27f78ed18cdfc872312f9b2205ed0c9dd997f1747a363f1a9d8cbf8dce4747ce8ec399d6b25dac97b2aa144ed5a06f25871c6e217786f74ec90ac0f5a9964a4b73474e99cc5166d40d94eb7df36ab5ec3cecd8cc65cdb8910a056593e73b0e1342435dcf33ad0a1b945b2956c44a728c6a2e6bdee636ccd864870738f82d2bfc8c0397fab652d59446db4d17339be431a2511bf10e9792b3c566a4f1c93a524843d7fd4724300cbf3deab9bb34def582c40d87011dba748f06f1256ec0832d64c9f2f9abca021582b5aa59cb8518a80d79b4c262c3b13334ba819d27876cb14d6dcfd17dcd4557fc3a939f504c331806e1de20f62e57e7b3424c2873dceafc508d26d68c024a4396ac2629404904e4f21634883ddc942bce3a573e47ac6ed2c7923b7b55fa13b899730d18436caf7ca56d2af166adb4b24070c1b84f05c07e20023f8e63e6b929f028164114c56b28a87dbae20f1b9897b236ca1ee3aa17344dbcd740274b20ab67d362d6c001110b6270019f0d375a95923f7921cb4ce9a205ffdc848edd3b60beacae1f66afb6853908ddccf7b9eb45883272c341c0c4c0f3a83fc868e8077413e6c5e4ebe4ecfb0451f662f33e723f05544c63d5c43685965ef7d07a6eea277ac53b10bf3c493fe25e6d87d8cd385ed57d0e110bc2308b29f7d23888326014eb7c8638393f98ccc6c936c47ee27a6fb8995385d33999754dbce52c0512979944d28c545aa53914e49734cb96394e70eca3f83e88ca7046e2068302560a72a71ab44c35b9205c95065b3aa91bec6a1a5b9a220b30246b3406d1fd777c6ddf29141506df302e99ac8df3a37dfae946f3379f6d8da647db1a1786341501d82711046e2c52c1638fba314b638e8368d3b8e383f1c9c5f968bb71ff7bf7077bf7b5fda3d6355b002e5c5d3ffc010000ffff0300b3bf6739d5080000"
+    ],
+    "rawHeaders": [
+      "Date",
+      "Fri, 24 Sep 2021 16:40:10 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "x-envoy-upstream-service-time",
+      "16",
+      "server",
+      "istio-envoy",
+      "content-encoding",
+      "gzip",
+      "vary",
+      "Accept-Encoding"
+    ],
+    "reqheaders": {
+      "accept": [
+        "*/*"
+      ],
+      "authorization": [
+        "ShippoToken shippo_test_26299434b7073941a967ae47719e0dca56927590"
+      ],
+      "accept-encoding": [
+        "gzip,deflate"
+      ],
+      "connection": [
+        "close"
+      ],
+      "host": "api.goshippo.com"
+    },
+    "responseIsBinary": false
+  },
+  {
+    "scope": "https://api.goshippo.com:443",
+    "method": "GET",
+    "path": "/tracks/shippo/SHIPPO_RETURNED",
+    "body": "",
+    "status": 200,
+    "response": [
+      "1f8b0800000000000003ec565d6fd33014fd2b569eb729495d27e9db0445548c32b51908a6a972ecebd690da95e30c01da7fe73add4a07cb3e1082175e2ac73ebe1fe7d8c7fd1679c7c5276d960bd3ae2b70d1289abf9c9c9ebe59ccc6e5d96c3a7e1e1d44823ba7bbb566a5371b8b530db84b2da0864ba8a3d1b7c8f035e0faa9d3d669ff85bce6ba4698b79fc0ecf62d36d7cbd1d541486c1a2ebcb608306d5d1f445c4a074db350ceae435011a0581037e405a2856e4497db731f923d3bc68faf7a83c38226f120546a5be35dd874360f496e227abb17efd94a0bbedc8f3439d94562314b923b2281e7384ee334398c8bc39496091bd17894c447ec03c2b1ada536bc5e3c805be3bae41d66de71423c349edca81028c3ef68e45d0b073fc40985b64de8613b5ac86de1bb3c8332c524c528a647714e3f5cf716809850d7b8357a6f5b4782106b309eac78432a00431cf8d61990c4632d2b20379d90068c047784a16a2bf856a73fa149d35637ed6c65b7d547107e211c600c797f57d7d876231f8dd5019643c1d23ce3a262195554f12c4b792a722529e52ca97684217677f2aff61458e9c6dbd0c579af06f1c31a9448f0f56dea147020405f06f271016f93f0ce1a2d7ec8a48db26eddb17f5b892d754fe0f2d7eafab9ecc56eb9944a5128801585a05c65b94886ac02fc19e07890ec7379367d357df36e8a54f6d29696f1d38fae840d775835095eb1776effe971fdb5937e8a7bb15b8a995000191d0e734a5315e74996d301957874219650ec535cce8ea7f349791fc58332491f71324f2d4ed764bef5f68e672d9171ad3432cdc9c6d9aa8635f9acfdaae31c2704da2bde0f6215ce68dce011c08d245f6c8b92d9b6964458e3d1e949d3a2e1391f9c66099ea8d66110d77fc677f2bd86f50683ef09574e77c20db2617c97633fc9677ee6e73e9fe9c176c2c5348fb3bca8d06b18cd68caa5623c4d184b53ca6375cb675e1c4f4ece66e3fb85fb8dbbd1d9ba841a8dc581eca1f4b71ec12751faf8bbd08bed286552d18a8a820a5ccc84a8d4805522e56298a50513b04fe9f3f1c9e4ed78d679f7ffb7f2afbe9517e1cf4dd3f025e0fcf9c5d577000000ffff0300bcd9c6d15b0a0000"
+    ],
+    "rawHeaders": [
+      "Date",
+      "Fri, 24 Sep 2021 16:40:10 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "x-envoy-upstream-service-time",
+      "17",
+      "server",
+      "istio-envoy",
+      "content-encoding",
+      "gzip",
+      "vary",
+      "Accept-Encoding"
+    ],
+    "reqheaders": {
+      "accept": [
+        "*/*"
+      ],
+      "authorization": [
+        "ShippoToken shippo_test_26299434b7073941a967ae47719e0dca56927590"
+      ],
+      "accept-encoding": [
+        "gzip,deflate"
+      ],
+      "connection": [
+        "close"
+      ],
+      "host": "api.goshippo.com"
+    },
+    "responseIsBinary": false
+  },
+  {
+    "scope": "https://api.goshippo.com:443",
+    "method": "GET",
+    "path": "/tracks/shippo/SHIPPO_UNKNOWN",
+    "body": "",
+    "status": 200,
+    "response": [
+      "1f8b0800000000000003ec52c16a1b3110fd15a1b363a4f5b28df71602a5a1ad63b04321212c5a69ec9d66575a24ada10dfef78eecb5eb43694bceb9499a37efbd99a7571ebdd22f68b7951dba1a3c2ff9ead3dd72795f3d2c3e2feebf2df8846be53d1e4aa1c1be77f414c0ef50430b3b6879f9caadea80ea4b8fce63fcc1be2a6c0916dd0bd8735fd58f65be9f245d1b948ee8086087b69d70658c8710aa8d775d22d5094a7e94651f09ad31e88376543189ddded0e527f6749ce752cc925337d8e853d3c32a899c18a3bbe0bb6d50abed25d3dd973353210a29ffc00451d1391399bc12f3ab2c5fcba2cc4529e554ccae1fa98106dba2556df54f644708a30ea8d5612f2c4288ec14445a1bdd7919fd0093dff924b34348731c4f95399a3f2b89754632f3525c4fb33c7b1ce74b4012c4965af9ba0136a6c91a1598070db803c32215284d1dbdb3a859caab031b19da8df39d4a294d89b0755a5d261686fa64ebf8e0eaef4452690f64cefcdddd881d7af3df584cb0dcd499cc6790cfeb22af3f88bad808b9c9446db4515a9af3e029bcf113ef2f16d960882e45fbf4becab7acf2397de110d416e8f9e979ff0b0000ffff0300257e94b244040000"
+    ],
+    "rawHeaders": [
+      "Date",
+      "Fri, 24 Sep 2021 16:40:11 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "x-envoy-upstream-service-time",
+      "16",
+      "server",
+      "istio-envoy",
+      "content-encoding",
+      "gzip",
+      "vary",
+      "Accept-Encoding"
+    ],
+    "reqheaders": {
+      "accept": [
+        "*/*"
+      ],
+      "authorization": [
+        "ShippoToken shippo_test_26299434b7073941a967ae47719e0dca56927590"
+      ],
+      "accept-encoding": [
+        "gzip,deflate"
+      ],
+      "connection": [
+        "close"
+      ],
+      "host": "api.goshippo.com"
+    },
+    "responseIsBinary": false
+  }
+]


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->

This PR aligns delivery-tracking/shipment-info use-case with [Station conventions](https://github.com/superfaceai/station/blob/main/CONVENTIONS.md) and turn tests to use Superface Testing.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Shippo and DHL tokens are public test tokens and we can have them in recordings.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
