### PR TITLE
Add `delivery-tracking/shipment-info` profile examples

### DIFF
--- a/capabilities/delivery-tracking/shipment-info/profile.supr
+++ b/capabilities/delivery-tracking/shipment-info/profile.supr
@@ -4,7 +4,7 @@ Track your shipment. Get the latest information on your shipment status.
 """
 
 name = "delivery-tracking/shipment-info"
-version = "1.1.0"
+version = "1.1.1"
 
 """
 Retrieve Shipment Status
@@ -81,6 +81,98 @@ usecase ShipmentInfo safe {
     A human-readable explanation specific to this occurrence of the problem.
     """
     detail
+  }
+
+  example Successful {
+    input {
+      trackingNumber = '00340434292135100148'
+    }
+
+    result [{
+      carrier = 'shippo',
+      destination = {
+        address = {
+          addressLocality = 'Chicago',
+          countryCode = 'US',
+          postalCode = '60611',
+        },
+      },
+      estimatedDeliveryDate = '2021-11-08T07:03:30.944Z',
+      events = [
+        {
+          statusCode = 'unknown',
+          statusText = 'The carrier has received the electronic shipment information.',
+          timestamp = '2021-11-01T19:54:08.906Z',
+        },
+        {
+          location = {
+            address = {
+              addressLocality = 'San Francisco',
+              countryCode = 'US',
+              postalCode = '94103',
+            },
+          },
+          statusCode = 'transit',
+          statusText = 'Your shipment has departed from the origin.',
+          timestamp = '2021-11-02T23:54:08.906Z',
+        },
+        {
+          location = {
+            address =  {
+              addressLocality = 'Memphis',
+              countryCode = 'US',
+              postalCode = '37501',
+            },
+          },
+          statusCode = 'failure',
+          statusText = 'The Postal Service has identified a problem with the processing of this item and you should contact support to get further information.',
+          timestamp = '2021-11-04T11:54:08.906Z',
+        },
+        {
+          location = {
+            address =  {
+              addressLocality = 'Chicago',
+              countryCode = 'US',
+              postalCode = '60611',
+            },
+          },
+          statusCode = 'delivered',
+          statusText = 'Your shipment has been delivered.',
+          timestamp = '2021-11-03T23:54:08.906Z',
+        },
+      ],
+      origin = {
+        address = {
+          addressLocality = 'San Francisco',
+          countryCode = 'US',
+          postalCode = '94103',
+        },
+      },
+      status = {
+        location = {
+          address = {
+            addressLocality = 'Chicago',
+            countryCode = 'US',
+            postalCode = '60611',
+          },
+        },
+        statusCode = 'delivered',
+        statusText = 'Your shipment has been delivered.',
+        timestamp = '2021-11-03T23:54:08.906Z',
+      },
+      trackingNumber = '00340434292135100148',
+      },
+    ]
+  }
+
+  example Failed {
+    input {
+      trackingNumber = '12345'
+    }
+
+    error {
+      title = 'No shipment with given tracking number found'
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->
This PR adds examples to `delivery-tracking/shipment-info` profile and bumps profile version to `1.1.1`

Rendered examples:

![image](https://user-images.githubusercontent.com/5206165/141255923-397baa5b-6596-41d8-b150-6f5bf55a8d1d.png)

@kysely I noticed that just the first item from list (events) is rendered.
![image](https://user-images.githubusercontent.com/5206165/141256147-8763d773-83ad-4e92-9240-77cf8f962b28.png)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
