### PR TITLE
feat: Adding examples to `crm/contacts`

### DIFF
--- a/capabilities/crm/contacts/profile.supr
+++ b/capabilities/crm/contacts/profile.supr
@@ -158,7 +158,7 @@ usecase Search safe {
   example SearchByEmail {
     input {
       property = "email"
-      operator = "="
+      operator = "EQ"
       value = "johndoe@example.com"
     }
 
@@ -178,7 +178,7 @@ usecase Search safe {
   example SearchById {
     input {
       property = "id"
-      operator = "="
+      operator = "EQ"
       value = "512"
     }
 
@@ -198,7 +198,7 @@ usecase Search safe {
   example SearchNotEqual {
     input {
       property = "firstName"
-      operator = "!="
+      operator = "NEQ"
       value = "Doe"
     }
 
@@ -212,7 +212,7 @@ usecase Search safe {
     }]
   }
 
-  example UnknowOperator {
+  example UnknownOperator {
     input {
       property = "email"
       operator = "%"

--- a/capabilities/crm/contacts/profile.supr
+++ b/capabilities/crm/contacts/profile.supr
@@ -4,7 +4,7 @@ Manage contacts in Customer Relation Management systems
 """
 
 name = "crm/contacts"
-version = "1.0.0"
+version = "1.0.1"
 
 """
 Create Contact

--- a/capabilities/crm/contacts/profile.supr
+++ b/capabilities/crm/contacts/profile.supr
@@ -30,33 +30,33 @@ usecase Create unsafe {
     detail
   }
 
-  // example success {
-  //   input {
-  //     email = "johndoe@example.com"
-  //     firstName = "John"
-  //     lastName = "Doe"
-  //     company = "Superface"
-  //     country = "USA"
-  //     customProperties = {
-  //       myproperty = "field value",
-  //     }
-  //   }
+  example success {
+    input {
+      email = "johndoe@example.com"
+      firstName = "John"
+      lastName = "Doe"
+      company = "Superface"
+      country = "USA"
+      customProperties = {
+        myproperty = "field value",
+      }
+    }
 
-  //   result {
-  //     id = "512"
-  //   }
-  // }
+    result {
+      id = "512"
+    }
+  }
   
-  // example error {
-  //   input {
-  //     email = "johndoe@example.com"
-  //   }
+  example error {
+    input {
+      email = "johndoe@example.com"
+    }
 
-  //   error {
-  //     title = "Unauthorized"
-  //     detail = "The API key provided is invalid"
-  //   }
-  // }
+    error {
+      title = "Unauthorized"
+      detail = "The API key provided is invalid"
+    }
+  }
 }
 
 """
@@ -84,34 +84,34 @@ usecase Update unsafe {
     detail
   }
 
-  // example success {
-  //   input {
-  //     id = "512"
-  //     email = "johndoe@example.com"
-  //     firstName = "John"
-  //     lastName = "Doe"
-  //     company = "Superface"
-  //     country = "USA"
-  //     customProperties = {
-  //       myproperty = "field value",
-  //     }
-  //   }
+  example success {
+    input {
+      id = "512"
+      email = "johndoe@example.com"
+      firstName = "John"
+      lastName = "Doe"
+      company = "Superface"
+      country = "USA"
+      customProperties = {
+        myproperty = "field value",
+      }
+    }
 
-  //   result {
-  //     id = "512"
-  //   }
-  // }
+    result {
+      id = "512"
+    }
+  }
   
-  // example error {
-  //   input {
-  //     email = "johndoe@example.com"
-  //   }
+  example error {
+    input {
+      email = "johndoe@example.com"
+    }
 
-  //   error {
-  //     title = "Unauthorized"
-  //     detail = "The API key provided is invalid"
-  //   }
-  // }
+    error {
+      title = "Unauthorized"
+      detail = "The API key provided is invalid"
+    }
+  }
 }
 
 """
@@ -155,75 +155,75 @@ usecase Search safe {
     detail
   }
 
-  // example SearchByEmail {
-  //   input {
-  //     property = "email"
-  //     operator = "="
-  //     value = "johndoe@example.com"
-  //   }
+  example SearchByEmail {
+    input {
+      property = "email"
+      operator = "="
+      value = "johndoe@example.com"
+    }
 
-  //   result [{
-  //     id = "512"
-  //     email = "johndoe@example.com"
-  //     firstName = "John"
-  //     lastName = "Doe"
-  //     company = "Superface"
-  //     country = "USA"
-  //     customProperties = {
-  //       myproperty = "field value"
-  //     }
-  //   }]
-  // }
+    result [{
+      id = "512"
+      email = "johndoe@example.com"
+      firstName = "John"
+      lastName = "Doe"
+      company = "Superface"
+      country = "USA"
+      customProperties = {
+        myproperty = "field value"
+      }
+    }]
+  }
 
-  // example SearchById {
-  //   input {
-  //     property = "id"
-  //     operator = "="
-  //     value = "512"
-  //   }
+  example SearchById {
+    input {
+      property = "id"
+      operator = "="
+      value = "512"
+    }
 
-  //   result [{
-  //     id = "512"
-  //     email = "johndoe@example.com"
-  //     firstName = "John"
-  //     lastName = "Doe"
-  //     company = "Superface"
-  //     country = "USA"
-  //     customProperties = {
-  //       myproperty = "field value"
-  //     }
-  //   }]
-  // }
+    result [{
+      id = "512"
+      email = "johndoe@example.com"
+      firstName = "John"
+      lastName = "Doe"
+      company = "Superface"
+      country = "USA"
+      customProperties = {
+        myproperty = "field value"
+      }
+    }]
+  }
 
-  // example SearchNotEqual {
-  //   input {
-  //     property = "firstName"
-  //     operator = "!="
-  //     value = "Doe"
-  //   }
+  example SearchNotEqual {
+    input {
+      property = "firstName"
+      operator = "!="
+      value = "Doe"
+    }
 
-  //   result [{
-  //     id = "512"
-  //     email = "johnsmith@example.com"
-  //     firstName = "John"
-  //     lastName = "Smiths"
-  //     company = "Example"
-  //     country = "USA"
-  //   }]
-  // }
+    result [{
+      id = "512"
+      email = "johnsmith@example.com"
+      firstName = "John"
+      lastName = "Smiths"
+      company = "Example"
+      country = "USA"
+    }]
+  }
 
-  // example UnknowOperator {
-  //   input {
-  //     property = "email"
-  //     operator = "%"
-  //     value "example.com"
-  //   }
+  example UnknowOperator {
+    input {
+      property = "email"
+      operator = "%"
+      value = "example.com"
+    }
 
-  //   error {
-  //     title = "Unknown operator"
-  //     detail = "Operator \"%\" is not recognized"
-  //   }
-  // }
+    error {
+      title = "Unknown operator"
+      detail = "Operator \"%\" is not recognized"
+    }
+  }
 }
 
 """


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

Uncommenting examples for `crm/contacts` capability, previously written by the author @freaz .

Also fixed `operator` values in examples for `Search` use case. The profile defines enum of `EQ` and `NEQ` but the examples used `=` `!=`. Checked against the maps, they do expect `EQ | NEQ`.

Fixed

Looks like this when rendered
<img width="877" alt="Screenshot 2021-11-11 at 13 35 28" src="https://user-images.githubusercontent.com/23558634/141299157-4902d2d6-a12d-4bea-b106-b3bc405db4eb.png">


<img width="869" alt="Screenshot 2021-11-11 at 13 35 35" src="https://user-images.githubusercontent.com/23558634/141299166-c7124a38-54bd-4aa9-9418-c4619a75e15e.png">

<img width="955" alt="Screenshot 2021-11-11 at 13 35 51" src="https://user-images.githubusercontent.com/23558634/141299192-a95a11e6-21ef-41f9-8742-b5ec88877b0e.png">


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
