### PR TITLE
feat: Add examples for email template profile

### DIFF
--- a/grid/communication/email-templates/profile.supr
+++ b/grid/communication/email-templates/profile.supr
@@ -4,7 +4,7 @@ List, create, update and get template content
 """
 
 name = "communication/email-templates"
-version = "1.0.1"
+version = "1.0.2"
 
 """
 List all templates

--- a/grid/communication/email-templates/profile.supr
+++ b/grid/communication/email-templates/profile.supr
@@ -12,6 +12,15 @@ Result isn't paginated, amount of returned templates depenends on provider.
 """
 usecase ListTemplates safe {
   result [Template]
+
+  example Successful {
+    result [
+      {
+        id = "d-8be96c63de164e6799c5dbf2521d7959"
+        name = "Email template name"
+      }
+    ]
+  }
 }
 
 """
@@ -28,6 +37,37 @@ usecase GetTemplateContent safe {
     text
     html
   }
+
+  example Successful {
+    input {
+      id = "d-ef6d417300f74f96a9f722050edae85f"
+    }
+
+    result {
+      subject = "Station test"
+      text = "Station usecase automated test
+
+From: {{from}}
+to: {{to}}
+
+Unsubscribe ( {{{unsubscribe}}} ) - Unsubscribe Preferences ( {{{unsubscribe_preferences}}} )"
+      html = """<!doctype html>
+<html>
+
+<head>
+  <meta name="viewport" content="width=device-width">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Integration Test Email #1</title>
+</head>
+
+<body class="">
+This template is used by integration tests only
+</body>
+
+</html>
+"""
+    }
+  }
 }
 
 """
@@ -43,6 +83,34 @@ usecase CreateTemplate unsafe {
   }
 
   result Template
+
+  example Successful {
+    input {
+      name = "Station Create template test (DELETE ME)"
+      subject = "Test Email"
+      text = "This template is used by integration tests only"
+      html = """<!doctype html>
+<html>
+
+<head>
+  <meta name="viewport" content="width=device-width">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Integration Test Email #1</title>
+</head>
+
+<body class="">
+This template is used by integration tests only
+</body>
+
+</html>
+"""
+    }
+
+    result {
+      id = "d-8be96c63de164e6799c5dbf2521d7959"
+      name = "Station Create template test (DELETE ME)"
+    }
+  }
 }
 
 """
@@ -59,6 +127,34 @@ usecase UpdateTemplate unsafe {
   }
 
   result Template
+
+  example Successful {
+    input {
+      name = "Station Update template test (DELETE ME)"
+      subject = "Test Email"
+      text = "This template is used by integration tests only"
+      html = """<!doctype html>
+<html>
+
+<head>
+  <meta name="viewport" content="width=device-width">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Integration Test Email #1</title>
+</head>
+
+<body class="">
+This template is used by integration tests only 2
+</body>
+
+</html>
+"""
+    }
+
+    result {
+      id = "d-8be96c63de164e6799c5dbf2521d7959"
+      name = "Station Update template test updated (DELETE ME)"
+    }
+  }
 }
 
 """

--- a/grid/communication/email-templates/profile.supr
+++ b/grid/communication/email-templates/profile.supr
@@ -16,8 +16,8 @@ usecase ListTemplates safe {
   example Successful {
     result [
       {
-        id = "d-8be96c63de164e6799c5dbf2521d7959"
-        name = "Email template name"
+        id = "template-id"
+        name = "example"
       }
     ]
   }
@@ -40,28 +40,23 @@ usecase GetTemplateContent safe {
 
   example Successful {
     input {
-      id = "d-ef6d417300f74f96a9f722050edae85f"
+      id = "example-id"
     }
 
     result {
-      subject = "Station test"
-      text = "Station usecase automated test
-
-From: {{from}}
-to: {{to}}
-
-Unsubscribe ( {{{unsubscribe}}} ) - Unsubscribe Preferences ( {{{unsubscribe_preferences}}} )"
+      subject = "Templated email example"
+      text = "Hi there, this is text content of example email."
       html = """<!doctype html>
 <html>
 
 <head>
   <meta name="viewport" content="width=device-width">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>Integration Test Email #1</title>
+  <title>Templated email example</title>
 </head>
 
 <body class="">
-This template is used by integration tests only
+Hi there, this is html content of example email.
 </body>
 
 </html>
@@ -86,20 +81,20 @@ usecase CreateTemplate unsafe {
 
   example Successful {
     input {
-      name = "Station Create template test (DELETE ME)"
-      subject = "Test Email"
-      text = "This template is used by integration tests only"
+      name = "example"
+      subject = "Templated email example"
+      text = "Hi there, this is text content of example email."
       html = """<!doctype html>
 <html>
 
 <head>
   <meta name="viewport" content="width=device-width">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>Integration Test Email #1</title>
+  <title>Templated email example</title>
 </head>
 
 <body class="">
-This template is used by integration tests only
+Hi there, this is html content of example email.
 </body>
 
 </html>
@@ -107,8 +102,8 @@ This template is used by integration tests only
     }
 
     result {
-      id = "d-8be96c63de164e6799c5dbf2521d7959"
-      name = "Station Create template test (DELETE ME)"
+      id = "template-id"
+      name = "example"
     }
   }
 }
@@ -130,20 +125,21 @@ usecase UpdateTemplate unsafe {
 
   example Successful {
     input {
-      name = "Station Update template test (DELETE ME)"
-      subject = "Test Email"
-      text = "This template is used by integration tests only"
+      id = "template-id"
+      name = "example"
+      subject = "Templated email example"
+      text = "Hi there, this is text content of example email."
       html = """<!doctype html>
 <html>
 
 <head>
   <meta name="viewport" content="width=device-width">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>Integration Test Email #1</title>
+  <title>Templated email example</title>
 </head>
 
 <body class="">
-This template is used by integration tests only 2
+Hi there, this is html content of example email.
 </body>
 
 </html>
@@ -151,8 +147,8 @@ This template is used by integration tests only 2
     }
 
     result {
-      id = "d-8be96c63de164e6799c5dbf2521d7959"
-      name = "Station Update template test updated (DELETE ME)"
+      id = "template-id"
+      name = "Templated email example"
     }
   }
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

Add examples for `communication/email-template`. I copied them from the tests. My only concern is with the long HTML and text examples. Should we do this or make them short one-liners?

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Trying to add examples for all profiles.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
