### PR TITLE
Fail CI/CD pipeline if lint or tests are failing

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -80,10 +80,8 @@ jobs:
       - run: cat /etc/hosts
       - run: yarn capabilities:check
       - run: yarn capabilities:lint
-        continue-on-error: true
       - run: yarn capabilities:structure
       - run: yarn capabilities:test
-        continue-on-error: true
 
   license_check:
     name: License check


### PR DESCRIPTION
Seems that we were able to clear all linter errors and have all usecases tested with recorded api calls.
This allows us to fail CI/CD if linter find some violation or tests are not passing.

Thanks everyone. ❤️ 