### PR TITLE
fix(social-media): parsing  rate limit in `social-media/followers` Twitter map

### DIFF
--- a/grid/social-media/followers/maps/twitter.suma
+++ b/grid/social-media/followers/maps/twitter.suma
@@ -59,29 +59,25 @@ operation MapFollower {
 
 //Twitter rate limits: https://developer.twitter.com/en/docs/twitter-api/rate-limits
 operation MapRateLimit {
-  totalRequestsHeader = args.headers['x-rate-limit-limit']
-  remainingRequestsHeader = args.headers['x-rate-limit-remaining']
-  resetTimestampHeader = args.headers['x-rate-limit-reset']
-
-  totalRequests = undefined
-  remainingRequests = undefined
+  totalRequests = parseInt(args.headers['x-rate-limit-limit'], 10)
+  remainingRequests = parseInt(args.headers['x-rate-limit-remaining'], 10)
   remainingRequestsPercentage = undefined
-  resetTimestamp = undefined
+  resetTimestamp = parseInt(args.headers['x-rate-limit-reset'], 10)
 
-  set if(totalRequestsHeader && parseInt(totalRequestsHeader, 10) !== 'NaN') {
-    totalRequests = parseInt(totalRequestsHeader, 10)
+  set if(isNaN(totalRequests)) {
+    totalRequests = undefined
   }
 
-  set if(remainingRequestsHeader && parseInt(remainingRequestsHeader, 10) !== 'NaN') {
-    remainingRequests = parseInt(remainingRequestsHeader, 10)
+  set if(isNaN(remainingRequests)) {
+    remainingRequests = undefined
   }
 
   set if(totalRequests > 0 && remainingRequests !== undefined) {
     remainingRequestsPercentage = remainingRequests / totalRequests * 100
   }
 
-  set if(resetTimestampHeader && parseInt(resetTimestampHeader, 10) !== 'NaN') {
-    resetTimestamp = parseInt(resetTimestampHeader, 10)
+  set if(isNaN(resetTimestamp, 10)) {
+    resetTimestamp = undefined
   }  
 
   return {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->

This PR fixes parsing rate limits in `social-media/followers` Twitter map in case that rate limits headers do not contain parsable number.

Bumped revision number to `social-media/followers@1.1-rev1` 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
