### PR TITLE
fix(twitter): Revert twitter provider parameters

### DIFF
--- a/providers/twitter.json
+++ b/providers/twitter.json
@@ -10,14 +10,6 @@
     {
       "name": "accessToken",
       "description": "User-authorized OAuth 2.0 access token"
-    },
-    {
-      "name": "clientId",
-      "description": "Client ID of the registered OAuth application"
-    },
-    {
-      "name": "clientSecret",
-      "description": "Client Secret of the registered OAuth application"
     }
   ],
   "defaultService": "default"


### PR DESCRIPTION
This reverts integration parameters changes to Twitter provider introduced in #197. Providers are immutable and cannot be updated just like this. Additionally these parameters are (so far) used only by oauth2/refresh-token profile, which might be confusing in context of other profiles.

Currently integration parameters can be passed to the map even when not specified in provider JSON, so I am keeping this behavior with the existing refresh-token map. The cleaner (though not universal) solution here would be to use default inputs.