### PR TITLE
Add ip geolocation profile title and description

### DIFF
--- a/grid/address/ip-geolocation/profile.supr
+++ b/grid/address/ip-geolocation/profile.supr
@@ -1,5 +1,9 @@
+"""
+IP geolocation lookup
+Lookup address and geolocation coordinates from IP address.
+"""
 name = "address/ip-geolocation"
-version = "1.0.0"
+version = "1.0.1"
 
 """
 IP Geolocation


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->
This PR adds missing title and description to `address/ip-geolocation` profile.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to have profile title and description rendered in Superface catalog.

This is how it is rendered in catalog:
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/5206165/155689880-25920197-01c5-434f-86fa-9e8f0f0a4bf8.png">



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
