### PR TITLE
fix(chat/messages/discord): Update pagination mapping

### DIFF
--- a/grid/chat/messages/maps/__snapshots__/discord.test.ts.snap
+++ b/grid/chat/messages/maps/__snapshots__/discord.test.ts.snap
@@ -125,6 +125,6 @@ Properties: {
   }
 }
 AST Path: definitions[0].statements[5].responseHandlers[1].statements[1]
-Original Map Location: Line 51, column 7",
+Original Map Location: Line 58, column 7",
 }
 `;

--- a/grid/chat/messages/maps/discord.suma
+++ b/grid/chat/messages/maps/discord.suma
@@ -33,9 +33,16 @@ map GetMessages {
     response 200 "application/json" {
       messages = call MapMessages(messages = body)
       rateLimit = call MapRateLimitDetails(headers = headers)
+      
+      return map result if ((messages.length < input.limit) || (messages.length === 0)) {
+        messages = messages
+        rateLimit = rateLimit
+      }
+
+      lastMessage = messages[messages.length - 1]
 
       map result {
-        nextPage = messages[messages.length - 1].id
+        nextPage = lastMessage.id
         messages = messages
         rateLimit = rateLimit
       }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Updates pagination in discord map. Does not return next page when number of returned record are less than limit from input or when they're empty.

<!--- Describe your changes in detail -->

## Motivation and Context
Throwing errors when indexing records when array is empty.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
