### PR TITLE
fix(chat/messages/slack): Filter deleted attachments

### DIFF
--- a/grid/chat/messages/maps/slack.suma
+++ b/grid/chat/messages/maps/slack.suma
@@ -100,14 +100,20 @@ operation MapMessages {
       }
   
       if (message.files) {
-        attachments = message.files.map(file => ({
-          id: file.id,
-          createdAt: file.created,
-          fileName: file.name,
-          mediaType: file.mimetype,
-          url: file.permalink_public,
-          preview: file.preview,
-        }));
+         attachments = message.files.reduce((attachAcc, file) => {
+          if (file.created !== undefined) {
+            attachAcc.push({
+              id: file.id,
+              createdAt: file.created,
+              fileName: file.name,
+              mediaType: file.mimetype,
+              url: file.permalink_public,
+              preview: file.preview,
+            });
+          }
+
+          return attachAcc;
+		    }, []);
   
         resultMessage.attachments = attachments;
       }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Adds filtering of attachments that are deleted from some message in slack.

<!--- Describe your changes in detail -->

## Motivation and Context
Throwing error on undefined fields.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
