### PR TITLE
fix(send-email/mailchimp): Fix sending body

### DIFF
--- a/grid/communication/send-email/maps/__snapshots__/mailchimp.test.ts.snap
+++ b/grid/communication/send-email/maps/__snapshots__/mailchimp.test.ts.snap
@@ -1,17 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`communication/send-email/mailchimp SendEmail when all inputs are correct sends email with attachments 1`] = `
-Ok {
-  "value": Object {
-    "messageId": "4c76ff21837c4e2fa8a4dc85f4948795",
-  },
+Err {
+  "error": "HTTPError: Expected HTTP error
+Properties: {
+  \\"title\\": \\"Send Email Failed\\",
+  \\"detail\\": \\"queued: undefined\\"
+}
+AST Path: definitions[0].statements[4].responseHandlers[0].statements[1]
+Original Map Location: Line 53, column 7",
 }
 `;
 
 exports[`communication/send-email/mailchimp SendEmail when all inputs are correct should return messageId as result 1`] = `
 Ok {
   "value": Object {
-    "messageId": "37e509d29bf04503976a08a0af18a96a",
+    "messageId": "36f3a99cac2d4e6d80cd1f32c584f346",
   },
 }
 `;
@@ -24,6 +28,6 @@ Properties: {
   \\"detail\\": \\"Validation error: {\\\\\\"message\\\\\\":{\\\\\\"from_email\\\\\\":\\\\\\"An email address must contain a single @\\\\\\"}}\\"
 }
 AST Path: definitions[0].statements[4].responseHandlers[1].statements[1]
-Original Map Location: Line 62, column 7",
+Original Map Location: Line 65, column 7",
 }
 `;

--- a/grid/communication/send-email/maps/mailchimp.suma
+++ b/grid/communication/send-email/maps/mailchimp.suma
@@ -5,8 +5,8 @@ profile = "communication/send-email@2.1"
 provider = "mailchimp"
 
 map SendEmail {
-  body = {
-    message: {
+  set {
+    message = {
       from_email: input.from,
       to: [
         {
@@ -19,15 +19,15 @@ map SendEmail {
   }
 
   set if (input.text) {
-    body.text = input.text
+    message.text = input.text
   }
 
   set if (input.html) {
-    body.html = input.html
+    message.html = input.html
   }
 
-  set if (input.attachments) {
-    body.attachments = input.attachments.map(attachment => {
+  set if (Array.isArray(input.attachments)) {
+    message.attachments = input.attachments.map(attachment => {
       return {
         content: attachment.content,
         name: attachment.filename,
@@ -40,7 +40,9 @@ map SendEmail {
     security "api_key"
     
     request {
-      body = body
+      body = {
+        message: message
+      }
     }
 
     response 200 {
@@ -57,6 +59,7 @@ map SendEmail {
     response 500 {
       map error if (body) {
         title = "Internal server Error"
+        detail = body.message || `${body}`
       }
 
       map error if (body.name === "ValidationError") {

--- a/nock/communication/send-email/mailchimp/SendEmail/recording-69d92e19523ced971d75fcf53bc8882e.json
+++ b/nock/communication/send-email/mailchimp/SendEmail/recording-69d92e19523ced971d75fcf53bc8882e.json
@@ -12,32 +12,32 @@
             "type": "to"
           }
         ],
-        "subject": "Station test with attachements"
+        "subject": "Station test with attachements",
+        "text": "Station test - mailchimp",
+        "attachments": [
+          {
+            "content": "dGVzdA==",
+            "name": "test.txt",
+            "type": "text/plain"
+          },
+          {
+            "content": "dGVzdC==",
+            "name": "test2.json",
+            "type": "application/json"
+          }
+        ]
       },
-      "text": "Station test - mailchimp",
-      "attachments": [
-        {
-          "content": "dGVzdA==",
-          "name": "test.txt",
-          "type": "text/plain"
-        },
-        {
-          "content": "dGVzdC==",
-          "name": "test2.json",
-          "type": "application/json"
-        }
-      ],
       "key": "SECURITY_api_key"
     },
     "status": 200,
     "response": [
-      "1f8b08000000000000030ccac10ac2300c00d07fc95906ce6ced76f23f444668139d64ad34ed49fcf7f5f8e03d7ec007ed0a2bbc5935df231f79b0f6e5221478c8e50517b04ab5593fc6a9766f7becc0e06691f1ea6f2e208f429e30063f092ee8dd32f558f8c3a16e85c972823535d5fff3040000ffff03002750fa7b74000000"
+      "1f8b08000000000000030c8b4d0e40301406eff2d6227e9ed7b0720f1129fdd0a4525457e2eeba9cc9ccf0120e6d1d75b4c339df1b1c3e0ff1c4bdea05b9bf37ca283cfa8921355744844966b2266129b3aec0522956cc4887cc6d8986450a5e6ba66ffc010000ffff0300e72257d861000000"
     ],
     "rawHeaders": [
       "server",
       "nginx/1.12.2",
       "date",
-      "Mon, 11 Apr 2022 14:19:41 GMT",
+      "Mon, 09 May 2022 13:59:22 GMT",
       "content-type",
       "application/json; charset=utf-8",
       "transfer-encoding",

--- a/nock/communication/send-email/mailchimp/SendEmail/recording-7a339eba37fc9478d50c9f0221b1f286.json
+++ b/nock/communication/send-email/mailchimp/SendEmail/recording-7a339eba37fc9478d50c9f0221b1f286.json
@@ -12,20 +12,20 @@
             "type": "to"
           }
         ],
-        "subject": "Station test"
+        "subject": "Station test",
+        "text": "Station test - mailchimp"
       },
-      "text": "Station test - mailchimp",
       "key": "SECURITY_api_key"
     },
     "status": 200,
     "response": [
-      "1f8b08000000000000030cca4d0e82301006d0bbccda9051e4a7acbc873164a45f15535ad2695786bbd3e54bdef34fd864f534d117dec787c5161b2d3b9293054d4c1fba9066c945eb51845c3dafb6a21dd0b1b137f3767cefb835432f3c0a8bbb8e627aa931e18725cf09a231d0148af7c7eb040000ffff030048569eb274000000"
+      "1f8b08000000000000030ccac10ac2300c00d07fc95986ae5dd976f23f444648529d64ad34ed49fcf7f5f8e03d7e2007ee0a2bbc4535df598e3c58fb4a894832e4f2820b58c5daac1f9354bbb79d3b5c880e97859046f61278be12dfa21b699a7d743ef458e42354b7226839c19a9aeaff79020000ffff0300d8cf33c674000000"
     ],
     "rawHeaders": [
       "server",
       "nginx/1.12.2",
       "date",
-      "Mon, 11 Apr 2022 14:19:40 GMT",
+      "Mon, 09 May 2022 13:59:21 GMT",
       "content-type",
       "application/json; charset=utf-8",
       "transfer-encoding",

--- a/nock/communication/send-email/mailchimp/SendEmail/recording-a10433b7962d1f96e4eee9be0141d6dd.json
+++ b/nock/communication/send-email/mailchimp/SendEmail/recording-a10433b7962d1f96e4eee9be0141d6dd.json
@@ -24,7 +24,7 @@
       "server",
       "nginx/1.12.2",
       "date",
-      "Mon, 11 Apr 2022 14:19:41 GMT",
+      "Mon, 09 May 2022 13:59:22 GMT",
       "content-type",
       "application/json; charset=utf-8",
       "transfer-encoding",


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

Mailchimp map for `communication/send-email` is currently broken, as `message` properties are directly attached directly to body. This results in blank email being sent.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
