### PR TITLE
fix(send-email/mailchimp): Handle queued email

### DIFF
--- a/grid/communication/send-email/maps/__snapshots__/mailchimp.test.ts.snap
+++ b/grid/communication/send-email/maps/__snapshots__/mailchimp.test.ts.snap
@@ -1,21 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`communication/send-email/mailchimp SendEmail when all inputs are correct sends email with attachments 1`] = `
-Err {
-  "error": "HTTPError: Expected HTTP error
-Properties: {
-  \\"title\\": \\"Send Email Failed\\",
-  \\"detail\\": \\"queued: undefined\\"
-}
-AST Path: definitions[0].statements[4].responseHandlers[0].statements[1]
-Original Map Location: Line 53, column 7",
+Ok {
+  "value": Object {
+    "messageId": "531f336602e04044bceba9d169b2046c",
+  },
 }
 `;
 
 exports[`communication/send-email/mailchimp SendEmail when all inputs are correct should return messageId as result 1`] = `
 Ok {
   "value": Object {
-    "messageId": "36f3a99cac2d4e6d80cd1f32c584f346",
+    "messageId": "d16ae96d3dd64d10bbd800c55a12c3ac",
   },
 }
 `;
@@ -28,6 +24,6 @@ Properties: {
   \\"detail\\": \\"Validation error: {\\\\\\"message\\\\\\":{\\\\\\"from_email\\\\\\":\\\\\\"An email address must contain a single @\\\\\\"}}\\"
 }
 AST Path: definitions[0].statements[4].responseHandlers[1].statements[1]
-Original Map Location: Line 65, column 7",
+Original Map Location: Line 69, column 7",
 }
 `;

--- a/grid/communication/send-email/maps/mailchimp.suma
+++ b/grid/communication/send-email/maps/mailchimp.suma
@@ -45,14 +45,18 @@ map SendEmail {
       }
     }
 
-    response 200 {
-      map result if (body[0].status === "sent") {
+    response 200 "application/json" {
+      set {
+        msgStatus = body[0].status
+      }
+      // the sending status of the recipient Possible values: "sent", "queued", "scheduled", "rejected", or "invalid".
+      return map result if (msgStatus === "sent" || msgStatus === "queued" || msgStatus === "scheduled") {
         messageId = body[0]._id
       }
 
-      map error if (body[0].status !== "sent") {
+      return map error {
         title = "Send Email Failed",
-        detail = (`${body[0].status}: ${body[0].reject_reason}`)
+        detail = (`${msgStatus}: ${body[0].reject_reason}`)
       }
     }
 

--- a/nock/communication/send-email/mailchimp/SendEmail/recording-69d92e19523ced971d75fcf53bc8882e.json
+++ b/nock/communication/send-email/mailchimp/SendEmail/recording-69d92e19523ced971d75fcf53bc8882e.json
@@ -31,13 +31,13 @@
     },
     "status": 200,
     "response": [
-      "1f8b08000000000000030c8b4d0e40301406eff2d6227e9ed7b0720f1129fdd0a4525457e2eeba9cc9ccf0120e6d1d75b4c339df1b1c3e0ff1c4bdea05b9bf37ca283cfa8921355744844966b2266129b3aec0522956cc4887cc6d8986450a5e6ba66ffc010000ffff0300e72257d861000000"
+      "1f8b08000000000000030cca4d0a80201446d1bdbc7184a509366a1f11e1cf670586953a8af69ec37bb8f34b38f51168a41d21c4c9e18c6d2a171eaf2ddaf86cd450ca3a97549fbba0c055590f5773e09de75c4ad683092684b1305ab94e2ad333212d7dcb0f0000ffff03003a063dd961000000"
     ],
     "rawHeaders": [
       "server",
       "nginx/1.12.2",
       "date",
-      "Mon, 09 May 2022 13:59:22 GMT",
+      "Mon, 09 May 2022 14:26:41 GMT",
       "content-type",
       "application/json; charset=utf-8",
       "transfer-encoding",

--- a/nock/communication/send-email/mailchimp/SendEmail/recording-7a339eba37fc9478d50c9f0221b1f286.json
+++ b/nock/communication/send-email/mailchimp/SendEmail/recording-7a339eba37fc9478d50c9f0221b1f286.json
@@ -19,13 +19,13 @@
     },
     "status": 200,
     "response": [
-      "1f8b08000000000000030ccac10ac2300c00d07fc95986ae5dd976f23f444648529d64ad34ed49fcf7f5f8e03d7e2007ee0a2bbc4535df598e3c58fb4a894832e4f2820b58c5daac1f9354bbb79d3b5c880e97859046f61278be12dfa21b699a7d743ef458e42354b7226839c19a9aeaff79020000ffff0300d8cf33c674000000"
+      "1f8b08000000000000030cca410ac2301005d0bbcc5a4a626dd0aebc874899ce7cb59226924956e2ddcdf2c1bb7d093b6f91667a21c67c55ec79b0f64179b060c8e54907b2cab5593f8654bb974d3bd407c625e8a81a4eeaddbaead9399926f64719597a2c7843ea52c09613cda9c5f8bbff010000ffff0300f894007e74000000"
     ],
     "rawHeaders": [
       "server",
       "nginx/1.12.2",
       "date",
-      "Mon, 09 May 2022 13:59:21 GMT",
+      "Mon, 09 May 2022 14:26:40 GMT",
       "content-type",
       "application/json; charset=utf-8",
       "transfer-encoding",

--- a/nock/communication/send-email/mailchimp/SendEmail/recording-a10433b7962d1f96e4eee9be0141d6dd.json
+++ b/nock/communication/send-email/mailchimp/SendEmail/recording-a10433b7962d1f96e4eee9be0141d6dd.json
@@ -24,7 +24,7 @@
       "server",
       "nginx/1.12.2",
       "date",
-      "Mon, 09 May 2022 13:59:22 GMT",
+      "Mon, 09 May 2022 14:26:41 GMT",
       "content-type",
       "application/json; charset=utf-8",
       "transfer-encoding",


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->

Mailchimp map expects the status of the message to be `sent`, however it can be also `queued` (as is the case of messages with attachments), so this fixes the map to handle `sent`, `queued`, or `scheduled` messages as successfully submitted.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
