### PR TITLE
fix: don't use `title` as video description on Facebook in social-media/PublishPost

### DIFF
--- a/grid/social-media/publish-post/maps/facebook.suma
+++ b/grid/social-media/publish-post/maps/facebook.suma
@@ -37,7 +37,7 @@ map PublishPost {
     token = parameters.accessToken
   }
 
-  call PublishVideo(video = videos[0], caption = input.title || input.text, pageAccessToken = token) if (videos.length > 0) {
+  call PublishVideo(video = videos[0], description = input.text, pageAccessToken = token) if (videos.length > 0) {
       map error if (outcome.error) outcome.error
       return map result if (outcome.data) {
         postId = outcome.data.postId
@@ -205,7 +205,7 @@ operation PublishVideo {
       query {
         access_token = args.pageAccessToken,
         published = true,
-        description = args.caption
+        description = args.description
         fields = "id,permalink_url"
       }
     }


### PR DESCRIPTION
## Description

`input.title` was used as the primary description of an uploaded Facebook video, with `input.text` as the fallback. This change makes it so that only `input.text` is considered.

## Motivation and Context

This behavior is unexpected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
