### PR TITLE
fix: Remove entity type prefix in maps `CreateLead`

### DIFF
--- a/grid/recruitment/create-lead/maps/__snapshots__/breezy-hr.test.ts.snap
+++ b/grid/recruitment/create-lead/maps/__snapshots__/breezy-hr.test.ts.snap
@@ -23,7 +23,7 @@ Original Map Location: Line 16, column 5",
 exports[`recruitment/create-lead/breezy-hr CreateLead should perform successfully 1`] = `
 Ok {
   "value": Object {
-    "id": "LEAD:c82c6b873b5701",
+    "id": "c82c6b873b5701",
     "jobId": "f1cfc5572a5701",
     "rateLimit": Object {
       "bucket": "breezy-hr",

--- a/grid/recruitment/create-lead/maps/__snapshots__/workable.test.ts.snap
+++ b/grid/recruitment/create-lead/maps/__snapshots__/workable.test.ts.snap
@@ -19,7 +19,7 @@ Original Map Location: Line 76, column 7",
 exports[`recruitment/create-lead/workable CreateLead should perform successfully 1`] = `
 Ok {
   "value": Object {
-    "id": "LEAD:d3dbf54",
+    "id": "d3dbf54",
     "jobId": "FCFA80DF09",
     "rateLimit": Object {
       "bucket": "workable",

--- a/grid/recruitment/create-lead/maps/breezy-hr.suma
+++ b/grid/recruitment/create-lead/maps/breezy-hr.suma
@@ -185,7 +185,7 @@ operation CreateLead {
     response 200 "application/json" {
       return {
           lead = {
-            id: 'LEAD:' + body._id,
+            id: body._id,
             jobId: lead.jobId
           },
           rateLimit = call MapRateLimit(headers = headers) 

--- a/grid/recruitment/create-lead/maps/mock.suma
+++ b/grid/recruitment/create-lead/maps/mock.suma
@@ -7,11 +7,11 @@ CreateLead map
 map CreateLead {
     
   return map result if (input.jobId) {
-    id = 'LEAD:LEAD_ID'
+    id = 'LEAD_ID'
     jobId = 'JOB_ID'
   }
 
   return map result {
-    id = 'LEAD:LEAD_ID'
+    id = 'LEAD_ID'
   }
 }

--- a/grid/recruitment/create-lead/maps/mock.test.ts
+++ b/grid/recruitment/create-lead/maps/mock.test.ts
@@ -27,7 +27,7 @@ describe('recruitment/create-lead/mock', () => {
         );
 
         expect(result.isOk() && (result.value as any)).toEqual({
-          id: 'LEAD:LEAD_ID',
+          id: 'LEAD_ID',
           jobId: 'JOB_ID',
         });
       });
@@ -47,7 +47,7 @@ describe('recruitment/create-lead/mock', () => {
       const result = await usecase.perform(sampleLead, { provider });
 
       expect(result.isOk() && (result.value as any)).toEqual({
-        id: 'LEAD:LEAD_ID',
+        id: 'LEAD_ID',
       });
     });
   });

--- a/grid/recruitment/create-lead/maps/workable.suma
+++ b/grid/recruitment/create-lead/maps/workable.suma
@@ -60,7 +60,7 @@ map CreateLead {
 
     response 201 "application/json" {
       map result {
-        id = 'LEAD:' + body.candidate.id
+        id = body.candidate.id
         jobId = body.candidate.job.shortcode
         rateLimit = call MapRateLimit(headers = headers)
       }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Removes entity type prefix within id.

<!--- Describe your changes in detail -->

## Motivation and Context
Not needed at the moment.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
