### PR TITLE
fix: move get-cv recording to right location

### DIFF
--- a/grid/recruitment/get-cv/maps/mock.test.ts
+++ b/grid/recruitment/get-cv/maps/mock.test.ts
@@ -1,10 +1,12 @@
 import { SuperfaceTest } from '@superfaceai/testing';
 
+import { buildSuperfaceTest } from '../../../test-config';
+
 describe('recruitment/get-cv/mock', () => {
   let superface: SuperfaceTest;
 
   beforeEach(() => {
-    superface = new SuperfaceTest({
+    superface = buildSuperfaceTest({
       profile: 'recruitment/get-cv',
       provider: 'mock',
     });

--- a/grid/recruitment/get-cv/maps/recordings/mock.recording.json
+++ b/grid/recruitment/get-cv/maps/recordings/mock.recording.json
@@ -1,0 +1,5 @@
+{
+  "recruitment/get-cv/mock/GetCV": {
+    "1df997ff726b9f28586da2212f51067d": []
+  }
+}

--- a/recordings/recruitment/get-cv/mock.recording.json
+++ b/recordings/recruitment/get-cv/mock.recording.json
@@ -1,6 +1,0 @@
-{
-  "recruitment/get-cv/mock/GetCV": {
-    "f9dc26dfb5ba0309eac14236c2781671": [],
-    "eb485296977fbd9863bb8ef67c5e043a": []
-  }
-}


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->

This PR moves `recruitment/get-cv` `mock` map test recording to right location (according to Station conventions).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This bug was introduced in #331.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
