### PR TITLE
fix(deepl): Send payload in body, parametrize provider

### DIFF
--- a/grid/language/translate/maps/__snapshots__/deepl.test.ts.snap
+++ b/grid/language/translate/maps/__snapshots__/deepl.test.ts.snap
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DeepL TranslateText failes - Bad Request 1`] = `
+exports[`DeepL TranslateText fails with Bad Request 1`] = `
 Err {
   "error": "MappedHTTPError: Expected HTTP error
 Properties: {
   \\"title\\": \\"Bad request\\",
-  \\"detail\\": \\"\\\\\\"Parameter 'text' not specified.\\\\\\"\\"
+  \\"detail\\": \\"Parameter 'text' not specified.\\"
 }
 AST Path: definitions[0].statements[0].responseHandlers[1].statements[0]
-Original Map Location: Line 27, column 13",
+Original Map Location: Line 32, column 13",
 }
 `;
 
 exports[`DeepL TranslateText performs correctly 1`] = `
 Ok {
   "value": Object {
-    "sourceLanguage": "SK",
-    "text": "Testing",
+    "sourceLanguage": "EN",
+    "text": "Hallo, Welt!",
   },
 }
 `;

--- a/grid/language/translate/maps/deepl.suma
+++ b/grid/language/translate/maps/deepl.suma
@@ -5,11 +5,11 @@ provider = "deepl"
 Translate text
 """
 map TranslateText {
-    http GET "/v2/translate" {
-        security 'apikey'
+    http POST "/v2/translate" {
+        security 'authkey'
 
         request {
-            query {
+            body {
                 text = input.text
                 source_lang = input.sourceLanguage
                 target_lang = input.targetLanguage

--- a/grid/language/translate/maps/deepl.suma
+++ b/grid/language/translate/maps/deepl.suma
@@ -5,10 +5,14 @@ provider = "deepl"
 Translate text
 """
 map TranslateText {
+    // https://www.deepl.com/docs-api/translate-text/translate-text/
     http POST "/v2/translate" {
-        security 'authkey'
+        security "apikey"
 
-        request {
+        request "application/x-www-form-urlencoded" {
+            headers {
+              "accept" = "application/json"
+            }
             body {
                 text = input.text
                 source_lang = input.sourceLanguage
@@ -23,6 +27,7 @@ map TranslateText {
             }
         }
 
+        // https://www.deepl.com/docs-api/api-access/error-handling/
         response 400 {
             map error {
                 title = "Bad request"

--- a/grid/language/translate/maps/deepl.test.ts
+++ b/grid/language/translate/maps/deepl.test.ts
@@ -14,26 +14,27 @@ describe('DeepL', () => {
 
   describe('TranslateText', () => {
     it('performs correctly', async () => {
-      await expect(
-        superface.run({
-          useCase: 'TranslateText',
-          input: {
-            text: 'Testovanie',
-            targetLanguage: 'EN',
-          },
-        })
-      ).resolves.toMatchSnapshot();
+      const result = await superface.run({
+        useCase: 'TranslateText',
+        input: {
+          text: 'Hello, world!',
+          sourceLanguage: 'EN',
+          targetLanguage: 'DE',
+        },
+      });
+      expect(result.isOk()).toBe(true);
+      expect(result).toMatchSnapshot();
     });
 
-    it('failes - Bad Request', async () => {
-      await expect(
-        superface.run({
-          useCase: 'TranslateText',
-          input: {
-            targetLanguage: 'EN',
-          },
-        })
-      ).resolves.toMatchSnapshot();
+    it('fails with Bad Request', async () => {
+      const result = await superface.run({
+        useCase: 'TranslateText',
+        input: {
+          targetLanguage: 'DE',
+        },
+      });
+      expect(result.isErr()).toBe(true);
+      expect(result).toMatchSnapshot();
     });
   });
 });

--- a/grid/language/translate/maps/recordings/deepl.recording.json
+++ b/grid/language/translate/maps/recordings/deepl.recording.json
@@ -2,59 +2,77 @@
   "language/translate/deepl/TranslateText": {
     "bad900cc1d9f2615dbfb50c66944d02c": [
       {
-        "scope": "https://api-free.deepl.com:443",
-        "method": "GET",
-        "path": "/v2/translate?text=Testovanie&target_lang=EN&auth_key=SECURITY_apikey",
-        "body": "",
+        "scope": "https://PARAMS_SUBDOMAIN.deepl.com:443",
+        "method": "POST",
+        "path": "/v2/translate?auth_key=SECURITY_apikey",
+        "body": "text=Hello%2C+world%21&source_lang=EN&target_lang=DE",
         "status": 200,
-        "response": {
+        "response": [
+          "1f8b0800000000000403ab562a294acc2bce492cc9cccf2b56b28aae564a492d494d2e494d892fce2f2d4a4e8dcf49cc4b2f4d4c4f55b25272f553d2512a49ad2801b23d127372f27514c253734a14956a636b013a912b364a000000"
+        ],
+        "rawHeaders": [
+          "server",
+          "nginx",
+          "date",
+          "Tue, 07 Mar 2023 22:33:50 GMT",
+          "content-type",
+          "application/json",
+          "transfer-encoding",
+          "chunked",
+          "access-control-allow-origin",
+          "*",
+          "content-encoding",
+          "gzip",
+          "strict-transport-security",
+          "max-age=63072000; includeSubDomains; preload",
+          "server-timing",
+          "l7_lb_tls;dur=109, l7_lb_idle;dur=0, l7_lb_receive;dur=0, l7_lb_total;dur=175",
+          "access-control-expose-headers",
+          "Server-Timing",
+          "connection",
+          "close"
+        ],
+        "responseIsBinary": false,
+        "decodedResponse": {
           "translations": [
             {
-              "detected_source_language": "SK",
-              "text": "Testing"
+              "detected_source_language": "EN",
+              "text": "Hallo, Welt!"
             }
           ]
-        },
-        "rawHeaders": [
-          "Server",
-          "nginx",
-          "Date",
-          "Fri, 05 Nov 2021 15:30:57 GMT",
-          "Content-Type",
-          "application/json",
-          "Content-Length",
-          "69",
-          "Connection",
-          "close",
-          "Access-Control-Allow-Origin",
-          "*"
-        ],
-        "responseIsBinary": false
+        }
       }
     ],
-    "1d788d339d646cf2006bd9b0ca39b1e7": [
+    "1d788d339d646cf2006bd9b0ca39b1e7": [],
+    "c4232f55500a85bed12c6dcb3bbf1316": [
       {
-        "scope": "https://api-free.deepl.com:443",
-        "method": "GET",
-        "path": "/v2/translate?target_lang=EN&auth_key=SECURITY_apikey",
-        "body": "",
+        "scope": "https://PARAMS_SUBDOMAIN.deepl.com:443",
+        "method": "POST",
+        "path": "/v2/translate?auth_key=SECURITY_apikey",
+        "body": "target_lang=DE",
         "status": 400,
         "response": {
-          "message": "\"Parameter 'text' not specified.\""
+          "message": "Parameter 'text' not specified."
         },
         "rawHeaders": [
-          "Server",
+          "server",
           "nginx",
-          "Date",
-          "Fri, 05 Nov 2021 15:30:57 GMT",
-          "Content-Type",
+          "date",
+          "Tue, 07 Mar 2023 22:33:50 GMT",
+          "content-type",
           "application/json",
-          "Content-Length",
-          "49",
-          "Connection",
-          "close",
-          "Access-Control-Allow-Origin",
-          "*"
+          "content-length",
+          "45",
+          "access-control-allow-origin",
+          "*",
+          "strict-transport-security",
+          "max-age=63072000; includeSubDomains; preload",
+          "server-timing",
+          "l7_lb_tls;dur=105, l7_lb_idle;dur=0, l7_lb_receive;dur=0, l7_lb_total;dur=108",
+          "access-control-expose-headers",
+          "Server-Timing",
+          "connection",
+          "close"
         ],
         "responseIsBinary": false
       }

--- a/providers/deepl.json
+++ b/providers/deepl.json
@@ -2,21 +2,24 @@
   "name": "deepl",
   "services": [
     {
-      "id": "free",
-      "baseUrl": "https://api-free.deepl.com"
-    },
-    {
-      "id": "pro",
-      "baseUrl": "https://api.deepl.com"
+      "id": "default",
+      "baseUrl": "https://{SUBDOMAIN}.deepl.com"
     }
   ],
+  "defaultService": "default",
   "securitySchemes": [
     {
-      "id": "authkey",
+      "id": "apikey",
       "type": "apiKey",
-      "in": "header",
-      "name": "DeepL-Auth-Key"
+      "in": "query",
+      "name": "auth_key"
     }
   ],
-  "defaultService": "free"
+  "parameters": [
+    {
+      "name": "SUBDOMAIN",
+      "default": "api-free",
+      "description": "API subdomain; set to 'api' for DeepL API Pro, or 'api-free' for DeepL API Free (default)."
+    }
+  ]
 }

--- a/providers/deepl.json
+++ b/providers/deepl.json
@@ -12,10 +12,10 @@
   ],
   "securitySchemes": [
     {
-      "id": "apikey",
+      "id": "authkey",
       "type": "apiKey",
-      "in": "query",
-      "name": "auth_key"
+      "in": "header",
+      "name": "DeepL-Auth-Key"
     }
   ],
   "defaultService": "free"

--- a/superface/super.json
+++ b/superface/super.json
@@ -1331,7 +1331,10 @@
           "id": "apikey",
           "apikey": "$DEEPL_API_KEY"
         }
-      ]
+      ],
+      "parameters": {
+        "SUBDOMAIN": "api-free"
+      }
     },
     "overpass-de": {
       "file": "../providers/overpass-de.json",


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

**This PR changes the `deepl` provider!**

## Description

Current DeepL map for `language/translate` is broken, basic request returns 400. It looks like DeepL stopped accepting payload in query parameters, and requires data to be passed in body.

Furthermore, it's not possible to use DeepL API Pro in current map, so I've added new `SUBDOMAIN` parameter. It defaults to `api-free` for the free API.

One caveat though: DeepL defines the following [authentication schema](https://www.deepl.com/docs-api/api-access/authentication/) in HTTP header:

```
Authorization: DeepL-Auth-Key [yourAuthKey]
```

However, we don't have any schema which allows formatting the Authorization header. Luckily the currently used scheme with `auth_key` query parameter works, but it's not documented and probably shouldn't be used.

## Motivation and Context

Reported by user on Discord.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
