### PR TITLE
fix(social-media/publish-post): Allow null fields

### DIFF
--- a/grid/social-media/publish-post/profile.supr
+++ b/grid/social-media/publish-post/profile.supr
@@ -4,7 +4,7 @@ Publish posts on social media such as Instagram, Facebook, or Twitter.
 """
 
 name = "social-media/publish-post"
-version = "2.0.0"
+version = "2.0.1"
 
 """
 Publish a Post
@@ -16,25 +16,25 @@ usecase PublishPost unsafe {
     Profile ID
     Identifier of a profile to publish to. May be optional with some providers.
     """
-    profileId string!
+    profileId string
 
     """
     Text
     Text of the post
     """
-    text string!
+    text string
 
     """
     Link
     URL to attach to the post
     """
-    link string!
+    link string
 
     """
     Title
     Title of the post, if supported by the provider (e.g. Pinterest). Ignored otherwise.
     """
-    title string!
+    title string
 
     """
     Media attachments


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->
This changes `string!` input fields to `string` to allow null values for all parameters.

Bumped patch version since this is fully backward compatible change.

## Motivation and Context

OneService interprets `field!` as required, which means we need to pass an empty string even for optional values.

Other social-media profiles don't use this type, so this is aligning the interface.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
