### PR TITLE
fix: ip geolocation tests check result status

### DIFF
--- a/grid/address/ip-geolocation/maps/ip-geocoding.ts
+++ b/grid/address/ip-geolocation/maps/ip-geocoding.ts
@@ -20,39 +20,39 @@ export const ipGeolocationTest = (
     describe('IpGeolocation', () => {
       describe('when api key is valid', () => {
         it('should return geolocation coordinates and address for valid IP address', async () => {
-          await expect(
-            superfaceTest.run(
-              {
-                useCase: 'IpGeolocation',
-                input: { ipAddress: '8.8.8.8' },
-              },
-              recordingOptions
-            )
-          ).resolves.toMatchSnapshot();
+          const result = await superfaceTest.run(
+            {
+              useCase: 'IpGeolocation',
+              input: { ipAddress: '8.8.8.8' },
+            },
+            recordingOptions
+          );
+          expect(() => result.unwrap()).not.toThrow();
+          expect(result).toMatchSnapshot();
         });
 
         it('should return client IP geolocation coordinates when no IP address specified in input', async () => {
-          await expect(
-            superfaceTest.run(
-              {
-                useCase: 'IpGeolocation',
-                input: {},
-              },
-              recordingOptions
-            )
-          ).resolves.toMatchSnapshot();
+          const result = await superfaceTest.run(
+            {
+              useCase: 'IpGeolocation',
+              input: {},
+            },
+            recordingOptions
+          );
+          expect(() => result.unwrap()).not.toThrow();
+          expect(result).toMatchSnapshot();
         });
 
         it('should return bad request error when IP address format is wrong', async () => {
-          await expect(
-            superfaceTest.run(
-              {
-                useCase: 'IpGeolocation',
-                input: { ipAddress: '256.256.256.256' },
-              },
-              recordingOptions
-            )
-          ).resolves.toMatchSnapshot();
+          const result = await superfaceTest.run(
+            {
+              useCase: 'IpGeolocation',
+              input: { ipAddress: '256.256.256.256' },
+            },
+            recordingOptions
+          );
+          expect(() => result.unwrap()).toThrow();
+          expect(result).toMatchSnapshot();
         });
       });
     });


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

Make test for `address/ip-geolocation` also test result status instead of just whether they match the snapshot.

## Motivation and Context

Without the check, an erroneous snapshot may be recorded, while the tests are still passing.

(I think this should also be added to `CONVENTIONS`?)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
