### PR TITLE
Add `replyTo` input to `communication/send-email` profile

### DIFF
--- a/grid/communication/send-email/maps/__snapshots__/mandrillapp.test.ts.snap
+++ b/grid/communication/send-email/maps/__snapshots__/mandrillapp.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`communication/send-email/mandrillapp SendEmail when all inputs are correct sends email with attachments 1`] = `
 Ok {
   "value": Object {
-    "messageId": "f37f5a6b0ddd4297b9c2923b2ca95d35",
+    "messageId": "6e66d342d89c45bf8bc0d645b0aec56d",
   },
 }
 `;
@@ -11,7 +11,7 @@ Ok {
 exports[`communication/send-email/mandrillapp SendEmail when all inputs are correct should return messageId as result 1`] = `
 Ok {
   "value": Object {
-    "messageId": "20ee22c5c741412e8351b623bb6e1ab0",
+    "messageId": "cbc9fa542d5d413b8577022e90b7a5ae",
   },
 }
 `;
@@ -23,7 +23,7 @@ Properties: {
   \\"title\\": \\"Invalid inputs\\",
   \\"detail\\": \\"Validation error: {\\\\\\"message\\\\\\":{\\\\\\"from_email\\\\\\":\\\\\\"An email address must contain a single @\\\\\\"}}\\"
 }
-AST Path: definitions[0].statements[4].responseHandlers[1].statements[1]
-Original Map Location: Line 69, column 7",
+AST Path: definitions[0].statements[5].responseHandlers[1].statements[1]
+Original Map Location: Line 77, column 7",
 }
 `;

--- a/grid/communication/send-email/maps/__snapshots__/postmark.test.ts.snap
+++ b/grid/communication/send-email/maps/__snapshots__/postmark.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`communication/send-email/postmark SendEmail when all inputs are correct sends email with attachments 1`] = `
 Ok {
   "value": Object {
-    "messageId": "9754979e-13ed-4eab-aacd-6f53d23bd2fd",
+    "messageId": "dcdb379f-1e96-4fcd-9418-d74cf079c7d5",
   },
 }
 `;
@@ -11,7 +11,7 @@ Ok {
 exports[`communication/send-email/postmark SendEmail when all inputs are correct should return messageId as result 1`] = `
 Ok {
   "value": Object {
-    "messageId": "813eb597-52dd-428a-b4d5-34678d97d9fb",
+    "messageId": "63e777eb-25c4-489c-9b46-7ba8605bc356",
   },
 }
 `;
@@ -24,6 +24,6 @@ Properties: {
   \\"detail\\": \\"Error parsing 'To': Illegal email address 'invalidemail'. It must contain the '@' symbol.\\"
 }
 AST Path: definitions[0].statements[2].responseHandlers[1].statements[0]
-Original Map Location: Line 39, column 7",
+Original Map Location: Line 40, column 7",
 }
 `;

--- a/grid/communication/send-email/maps/__snapshots__/sendgrid.test.ts.snap
+++ b/grid/communication/send-email/maps/__snapshots__/sendgrid.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`communication/send-email/sendgrid SendEmail when all inputs are correct sends email with attachments 1`] = `
 Ok {
   "value": Object {
-    "messageId": "B_bfTy-yQ4Wsi7IkFCLDhg",
+    "messageId": "I3DuZrM5TcynRf4GHapIeQ",
   },
 }
 `;
@@ -11,7 +11,7 @@ Ok {
 exports[`communication/send-email/sendgrid SendEmail when all inputs are correct should return messageId as result 1`] = `
 Ok {
   "value": Object {
-    "messageId": "6pxCmISvTXuqMk4lHAuAdQ",
+    "messageId": "R588AR2fTj2hUas1wGTEkQ",
   },
 }
 `;
@@ -23,7 +23,7 @@ Properties: {
   \\"title\\": \\"Invalid inputs\\",
   \\"detail\\": \\"Input 'from': The from email does not contain a valid address. Input 'to': Does not contain a valid address. Input 'subject': The subject is required. You can get around this requirement if you use a template with a subject defined or if every personalization has a subject defined. Input 'content': Unless a valid template_id is provided, the content parameter is required. There must be at least one defined content block. We typically suggest both text/plain and text/html blocks are included, but only one block is required.\\"
 }
-AST Path: definitions[0].statements[6].responseHandlers[1].statements[0]
-Original Map Location: Line 57, column 7",
+AST Path: definitions[0].statements[8].responseHandlers[1].statements[0]
+Original Map Location: Line 66, column 7",
 }
 `;

--- a/grid/communication/send-email/maps/mandrillapp.suma
+++ b/grid/communication/send-email/maps/mandrillapp.suma
@@ -1,7 +1,7 @@
 // Transactional API Quick Start: https://mailchimp.com/developer/transactional/guides/quick-start/
 // API Reference: https://mailchimp.com/developer/transactional/api/messages/send-new-message/
 
-profile = "communication/send-email@2.1"
+profile = "communication/send-email@2.2"
 provider = "mandrillapp"
 
 map SendEmail {
@@ -34,6 +34,14 @@ map SendEmail {
         type: attachment.type,
       }
     })
+  }
+
+  set if (input.replyTo) {
+    message.headers = [
+      {
+        'reply-to': input.replyTo
+      }
+    ]
   }
 
   http POST "/api/1.0/messages/send" {

--- a/grid/communication/send-email/maps/mandrillapp.test.ts
+++ b/grid/communication/send-email/maps/mandrillapp.test.ts
@@ -3,4 +3,5 @@ import { sendEmailTest } from './send-email';
 sendEmailTest('mandrillapp', {
   from: 'hello@demo.superface.org',
   to: 'hello@demo.superface.org',
+  replyTo: 'hello+replyto@demo.superface.org',
 });

--- a/grid/communication/send-email/maps/mock.suma
+++ b/grid/communication/send-email/maps/mock.suma
@@ -1,4 +1,4 @@
-profile = "communication/send-email@2.1"
+profile = "communication/send-email@2.2"
 provider = "mock"
 
 map SendEmail{

--- a/grid/communication/send-email/maps/postmark.suma
+++ b/grid/communication/send-email/maps/postmark.suma
@@ -1,6 +1,6 @@
 // API Reference: https://postmarkapp.com/developer/api/overview
 
-profile = "communication/send-email@2.1"
+profile = "communication/send-email@2.2"
 provider = "postmark"
 
 map SendEmail {
@@ -26,6 +26,7 @@ map SendEmail {
         TextBody = input.text
         HtmlBody = input.html
         Attachments = Attachments
+        ReplyTo = input.replyTo
       }
     }
     

--- a/grid/communication/send-email/maps/postmark.test.ts
+++ b/grid/communication/send-email/maps/postmark.test.ts
@@ -3,4 +3,5 @@ import { sendEmailTest } from './send-email';
 sendEmailTest('postmark', {
   from: 'demo@demo.superface.org',
   to: 'demo@demo.superface.org',
+  replyTo: 'demo+replyto@demo.superface.org',
 });

--- a/grid/communication/send-email/maps/recordings/mandrillapp.recording.json
+++ b/grid/communication/send-email/maps/recordings/mandrillapp.recording.json
@@ -15,19 +15,24 @@
               }
             ],
             "subject": "Station test",
-            "text": "Station test - mandrillapp"
+            "text": "Station test - mandrillapp",
+            "headers": [
+              {
+                "reply-to": "hello+replyto@demo.superface.org"
+              }
+            ]
           },
           "key": "SECURITY_api_key"
         },
         "status": 200,
         "response": [
-          "1f8b08000000000000030cca4d0ac2301006d0bbcc5a4a33fd51baf21e2265927e6a659a482659897737cb07eff6251cb22b2df4826aba6e385267f583fc90802ee5279dc88a946aed1862695ef7ad817b80394ce13cbad1312ec3e4fccc83f7339cf8bec58c37425933c452a42556d5dffd0f0000ffff030049e5246b74000000"
+          "1f8b080000000000000354ca410ec2201046e1bbccba692a9660bbf21ec63403fcd51a0a958195f1eeb275f9bdbcdb87b0f31668a6274248578f3df5520fe4951dfa941fd491142e55da2388a579d97c83b36e5a598fca6b3f9ecef6a28d1994c23458c39ad1c68c175c59325852a439d6103a7a5754f8bff8bdff000000ffff03007246bf3e89000000"
         ],
         "rawHeaders": [
           "server",
           "nginx/1.12.2",
           "date",
-          "Fri, 27 May 2022 12:03:27 GMT",
+          "Wed, 26 Apr 2023 15:19:58 GMT",
           "content-type",
           "application/json; charset=utf-8",
           "transfer-encoding",
@@ -52,8 +57,9 @@
           {
             "email": "hello@demo.superface.org",
             "status": "sent",
-            "_id": "20ee22c5c741412e8351b623bb6e1ab0",
-            "reject_reason": null
+            "_id": "cbc9fa542d5d413b8577022e90b7a5ae",
+            "reject_reason": null,
+            "queued_reason": null
           }
         ]
       }
@@ -85,19 +91,24 @@
                 "name": "test2.json",
                 "type": "application/json"
               }
+            ],
+            "headers": [
+              {
+                "reply-to": "hello+replyto@demo.superface.org"
+              }
             ]
           },
           "key": "SECURITY_api_key"
         },
         "status": 200,
         "response": [
-          "1f8b08000000000000030cca410a80201040d1bbcc3a22340b5b758f88189db104c5ca5c4577cfe57ffce5058ee8034c70700869268ea9cde5e4dba1e536dd3b34901f7c4aaecf55b83055d93cd57472740a07d311512ff468b4155a48232c6a4552c1b7fe000000ffff030084f4663e61000000"
+          "1f8b0800000000000003248acd0ac2301006df65cf528ab6a17af23d44ca36fbf5079246b3c9a9f8ee2ef436cccceb2044de023d684508e92988a9d1fa419ed9a34979a10b69e152d59e6f4585983961cc604dbb052e85fd1ab117b53a6e62cec139b9755719eebeeba779987c2bcea865f8de09fdde7f000000ffff030047206c9f7f000000"
         ],
         "rawHeaders": [
           "server",
           "nginx/1.4.6 (Ubuntu)",
           "date",
-          "Fri, 27 May 2022 12:03:28 GMT",
+          "Wed, 26 Apr 2023 15:19:58 GMT",
           "content-type",
           "application/json; charset=utf-8",
           "transfer-encoding",
@@ -122,7 +133,8 @@
           {
             "email": "hello@demo.superface.org",
             "status": "queued",
-            "_id": "f37f5a6b0ddd4297b9c2923b2ca95d35"
+            "queued_reason": "attachments",
+            "_id": "6e66d342d89c45bf8bc0d645b0aec56d"
           }
         ]
       }
@@ -141,7 +153,12 @@
                 "type": "to"
               }
             ],
-            "subject": ""
+            "subject": "",
+            "headers": [
+              {
+                "reply-to": "hello+replyto@demo.superface.org"
+              }
+            ]
           },
           "key": "SECURITY_api_key"
         },
@@ -151,9 +168,9 @@
         ],
         "rawHeaders": [
           "server",
-          "nginx/1.12.2",
+          "nginx/1.4.6 (Ubuntu)",
           "date",
-          "Fri, 27 May 2022 12:03:28 GMT",
+          "Wed, 26 Apr 2023 15:19:59 GMT",
           "content-type",
           "application/json; charset=utf-8",
           "transfer-encoding",

--- a/grid/communication/send-email/maps/recordings/postmark.recording.json
+++ b/grid/communication/send-email/maps/recordings/postmark.recording.json
@@ -10,12 +10,13 @@
           "To": "demo@demo.superface.org",
           "Subject": "Station test",
           "TextBody": "Station test - postmark",
-          "Attachments": null
+          "Attachments": null,
+          "ReplyTo": "demo+replyto@demo.superface.org"
         },
         "status": 200,
         "response": [
-          "1f8b08000000000004033cccbb0ec2301044d17fd91a47b6b38e1f150828104214a4a28bd94d441119394e85f8774c4333d5b9f3863e4100e2396d7fd32ceb8bf3383cb84979820ddcd6383f4b61da95eab4d45a48144af50a83f20165a325b69d35f78a2fbc2cc3c4a743a54eb51c8db7c2682281da0d222219d162671d794b7e8c3539e69cf23e114390ff839a5fcff0f9020000ffff",
-          "03007d0838dc9d000000"
+          "1f8b08000000000004033cccbd0ec2201885e17bf96621fc439934ea608c71b0931bd0cfc6a1c1009d8cf72e2e2e677adef3863183870997bcfd0dadeb0bcb2324a4b9ccb081db1a97676b38ed5a778209499822c28c5c7ba63ce79449e59c74f78e2f586b98f174e8d448b4d66224422745941b1219a232c4c6e00cd331496d7a722c25977d9e103cfb1ff4fc7a86cf170000ffff",
+          "0300cc9df46c9d000000"
         ],
         "rawHeaders": [
           "cache-control",
@@ -31,7 +32,7 @@
           "x-powered-by",
           "ASP.NET",
           "date",
-          "Mon, 11 Apr 2022 14:19:39 GMT",
+          "Wed, 26 Apr 2023 15:04:11 GMT",
           "strict-transport-security",
           "max-age=16000000;",
           "content-encoding",
@@ -46,8 +47,8 @@
         "responseIsBinary": false,
         "decodedResponse": {
           "To": "demo@demo.superface.org",
-          "SubmittedAt": "2022-04-11T14:19:40.2043675Z",
-          "MessageID": "813eb597-52dd-428a-b4d5-34678d97d9fb",
+          "SubmittedAt": "2023-04-26T15:04:11.0348838Z",
+          "MessageID": "63e777eb-25c4-489c-9b46-7ba8605bc356",
           "ErrorCode": 0,
           "Message": "OK"
         }
@@ -74,12 +75,13 @@
               "Name": "test2.json",
               "ContentType": "application/json"
             }
-          ]
+          ],
+          "ReplyTo": "demo+replyto@demo.superface.org"
         },
         "status": 200,
         "response": [
-          "1f8b08000000000004033cccb10ec2201485e177b9b3102ea5ad3069d4c118e3602737da7b691c1a0cd0c9f8eee2e272a6ef3f6f182238205ee2ee3732af2f4ec14f2c639a6103f7755c9ea530ed4b755a692d941188031a87d61925bb6d8f1d9a47c557ced9cf7c3e566afbd6d8deb2c0864918f6a3f07e22d185b621dd8ca403d5e494524c87480c4efd0f6a7ebbc0e70b0000ffff",
-          "0300e19a236a9d000000"
+          "1f8b08000000000004033c8c3d0fc2201400ffcb9ba5010ae563d2a88331c6c14e6e2defd13834184a27e37f972e2e37dddd07fa041e90e6b4dfd02ceb9b721c0235294fb083c73aceaf52080fa57a92cb9671c564d70bedb9f24234b6359a5bfdacf28d966598e872da9601c7d6b8c804b98ea9189039252c43a342e4c60583ba26e79c533e2624f0fc3fa8f9fd0adf1f000000ffff",
+          "03006477cd689d000000"
         ],
         "rawHeaders": [
           "cache-control",
@@ -95,7 +97,7 @@
           "x-powered-by",
           "ASP.NET",
           "date",
-          "Mon, 11 Apr 2022 14:19:40 GMT",
+          "Wed, 26 Apr 2023 15:04:11 GMT",
           "strict-transport-security",
           "max-age=16000000;",
           "content-encoding",
@@ -110,8 +112,8 @@
         "responseIsBinary": false,
         "decodedResponse": {
           "To": "demo@demo.superface.org",
-          "SubmittedAt": "2022-04-11T14:19:40.6871614Z",
-          "MessageID": "9754979e-13ed-4eab-aacd-6f53d23bd2fd",
+          "SubmittedAt": "2023-04-26T15:04:11.8375085Z",
+          "MessageID": "dcdb379f-1e96-4fcd-9418-d74cf079c7d5",
           "ErrorCode": 0,
           "Message": "OK"
         }
@@ -127,7 +129,8 @@
           "To": "invalidemail",
           "Subject": "",
           "TextBody": "",
-          "Attachments": null
+          "Attachments": null,
+          "ReplyTo": "demo+replyto@demo.superface.org"
         },
         "status": 422,
         "response": {
@@ -148,7 +151,7 @@
           "x-powered-by",
           "ASP.NET",
           "date",
-          "Mon, 11 Apr 2022 14:19:40 GMT",
+          "Wed, 26 Apr 2023 15:04:12 GMT",
           "content-length",
           "119",
           "strict-transport-security",

--- a/grid/communication/send-email/maps/recordings/sendgrid.recording.json
+++ b/grid/communication/send-email/maps/recordings/sendgrid.recording.json
@@ -25,7 +25,10 @@
               ]
             }
           ],
-          "attachments": null
+          "attachments": null,
+          "reply_to": {
+            "email": "demo+replyto@demo.superface.org"
+          }
         },
         "status": 202,
         "response": "",
@@ -33,13 +36,13 @@
           "Server",
           "nginx",
           "Date",
-          "Mon, 11 Apr 2022 14:19:40 GMT",
+          "Wed, 26 Apr 2023 13:46:07 GMT",
           "Content-Length",
           "0",
           "Connection",
           "close",
           "X-Message-Id",
-          "6pxCmISvTXuqMk4lHAuAdQ",
+          "R588AR2fTj2hUas1wGTEkQ",
           "Access-Control-Allow-Origin",
           "https://sendgrid.api-docs.io",
           "Access-Control-Allow-Methods",
@@ -92,7 +95,10 @@
               "filename": "test2.json",
               "type": "application/json"
             }
-          ]
+          ],
+          "reply_to": {
+            "email": "demo+replyto@demo.superface.org"
+          }
         },
         "status": 202,
         "response": "",
@@ -100,13 +106,13 @@
           "Server",
           "nginx",
           "Date",
-          "Mon, 11 Apr 2022 14:19:40 GMT",
+          "Wed, 26 Apr 2023 13:46:07 GMT",
           "Content-Length",
           "0",
           "Connection",
           "close",
           "X-Message-Id",
-          "B_bfTy-yQ4Wsi7IkFCLDhg",
+          "I3DuZrM5TcynRf4GHapIeQ",
           "Access-Control-Allow-Origin",
           "https://sendgrid.api-docs.io",
           "Access-Control-Allow-Methods",
@@ -143,7 +149,10 @@
               ]
             }
           ],
-          "attachments": null
+          "attachments": null,
+          "reply_to": {
+            "email": "demo+replyto@demo.superface.org"
+          }
         },
         "status": 400,
         "response": {
@@ -174,7 +183,7 @@
           "Server",
           "nginx",
           "Date",
-          "Mon, 11 Apr 2022 14:19:40 GMT",
+          "Wed, 26 Apr 2023 13:46:07 GMT",
           "Content-Type",
           "application/json",
           "Content-Length",

--- a/grid/communication/send-email/maps/send-email.ts
+++ b/grid/communication/send-email/maps/send-email.ts
@@ -9,6 +9,7 @@ export const sendEmailTest = (
   params: {
     from: string;
     to: string;
+    replyTo?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
   },

--- a/grid/communication/send-email/maps/sendgrid.suma
+++ b/grid/communication/send-email/maps/sendgrid.suma
@@ -1,7 +1,7 @@
 // SendGrid API Reference: https://sendgrid.com/docs/api-reference/"
 // Errors: https://sendgrid.api-docs.io/v3.0/mail-send/mail-send-errors
 
-profile = "communication/send-email@2.1"
+profile = "communication/send-email@2.2"
 provider = "sendgrid"
 
 map SendEmail {
@@ -9,10 +9,12 @@ map SendEmail {
     'personalizations.0.to.0.email': 'to',
     'from.email': 'from',
     'subject': 'subject',
+    'reply_to.email': 'replyTo'
   }
 
   content = []
   attachments = null
+  reply_to = null;
 
   set if (input.text) {
     content = content.concat([{ type: 'text/plain', value: input.text }])
@@ -32,6 +34,12 @@ map SendEmail {
     })
   }
 
+  set if (input.replyTo) {
+    reply_to = {
+      email: input.replyTo
+    }
+  }
+
   http POST "/v3/mail/send" {
     security "bearer_token"
     
@@ -44,6 +52,7 @@ map SendEmail {
           to: [{ email: input.to }], 
         }],
         attachments: attachments,
+        reply_to: reply_to
       }
     }
     

--- a/grid/communication/send-email/maps/sendgrid.test.ts
+++ b/grid/communication/send-email/maps/sendgrid.test.ts
@@ -3,4 +3,5 @@ import { sendEmailTest } from './send-email';
 sendEmailTest('sendgrid', {
   from: 'demo@demo.superface.org',
   to: 'demo@demo.superface.org',
+  replyTo: 'demo+replyto@demo.superface.org',
 });

--- a/grid/communication/send-email/profile.supr
+++ b/grid/communication/send-email/profile.supr
@@ -4,7 +4,7 @@ Send transactional email.
 """
 
 name = "communication/send-email"
-version = "2.1.0"
+version = "2.2.0"
 
 """
 Send Email
@@ -42,6 +42,12 @@ usecase SendEmail unsafe {
     The HTML email message.
     """
     html
+
+    """
+    Reply-To
+    The Reply-To email address.
+    """
+    replyTo
 
     """
     Attachments


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->
This PR adds `replyTo` optional input to `communication/send-email` profile. Profile minor version is bumped to v 2.2. Maps for `sendgrid`, `postmark`, `mandrillapp` and `mock` providers updated.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
